### PR TITLE
[Chore] #4 CI/CD 구조 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,8 +58,9 @@ jobs:
             # Docker 네트워크 생성 (없으면)
             docker network create aidom-network 2>/dev/null || true
 
-            # MySQL 컨테이너가 없으면 생성
+            # MySQL 컨테이너 관리
             if ! docker ps -a --format '{{.Names}}' | grep -q '^aidom-mysql$'; then
+              # 컨테이너가 없으면 생성
               docker run -d \
                 --name aidom-mysql \
                 --network aidom-network \
@@ -70,16 +71,26 @@ jobs:
                 -e MYSQL_PASSWORD=${{ secrets.DB_PASSWORD }} \
                 -e MYSQL_ROOT_PASSWORD=${{ secrets.DB_ROOT_PASSWORD }} \
                 mysql:8.0
+            elif ! docker ps --format '{{.Names}}' | grep -q '^aidom-mysql$'; then
+              # 컨테이너가 존재하지만 멈춰있으면 시작
+              docker start aidom-mysql
+            fi
 
-              # MySQL 준비 대기
-              echo "Waiting for MySQL to be ready..."
-              for i in $(seq 1 12); do
-                if docker exec aidom-mysql mysqladmin ping -h localhost --silent 2>/dev/null; then
-                  echo "MySQL is ready"
-                  break
-                fi
-                sleep 5
-              done
+            # MySQL 준비 대기
+            echo "Waiting for MySQL to be ready..."
+            MYSQL_READY=false
+            for i in $(seq 1 12); do
+              if docker exec aidom-mysql mysqladmin ping -h localhost -u root -p${{ secrets.DB_ROOT_PASSWORD }} --silent 2>/dev/null; then
+                echo "MySQL is ready"
+                MYSQL_READY=true
+                break
+              fi
+              sleep 5
+            done
+
+            if [ "$MYSQL_READY" = false ]; then
+              echo "MySQL failed to start"
+              exit 1
             fi
 
             # MySQL 컨테이너가 네트워크에 연결되어 있는지 확인

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build JAR
-        run: ./gradlew bootJar
+      - name: Build and test
+        run: ./gradlew build
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -53,16 +53,86 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          envs: REGISTRY,IMAGE_NAME,GITHUB_SHA
           script: |
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            # Docker 네트워크 생성 (없으면)
+            docker network create aidom-network 2>/dev/null || true
+
+            # MySQL 컨테이너가 없으면 생성
+            if ! docker ps -a --format '{{.Names}}' | grep -q '^aidom-mysql$'; then
+              docker run -d \
+                --name aidom-mysql \
+                --network aidom-network \
+                --restart unless-stopped \
+                -v mysql-data:/var/lib/mysql \
+                -e MYSQL_DATABASE=${{ secrets.DB_NAME }} \
+                -e MYSQL_USER=${{ secrets.DB_USERNAME }} \
+                -e MYSQL_PASSWORD=${{ secrets.DB_PASSWORD }} \
+                -e MYSQL_ROOT_PASSWORD=${{ secrets.DB_ROOT_PASSWORD }} \
+                mysql:8.0
+
+              # MySQL 준비 대기
+              echo "Waiting for MySQL to be ready..."
+              for i in $(seq 1 12); do
+                if docker exec aidom-mysql mysqladmin ping -h localhost --silent 2>/dev/null; then
+                  echo "MySQL is ready"
+                  break
+                fi
+                sleep 5
+              done
+            fi
+
+            # MySQL 컨테이너가 네트워크에 연결되어 있는지 확인
+            docker network connect aidom-network aidom-mysql 2>/dev/null || true
+
+            # 앱 배포
+            NEW_IMAGE="${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
+            docker pull $NEW_IMAGE
+
+            PREV_IMAGE=$(docker inspect aidom-backend --format='{{.Config.Image}}' 2>/dev/null || echo "")
+
             docker stop aidom-backend || true
             docker rm aidom-backend || true
+
             docker run -d \
               --name aidom-backend \
+              --network aidom-network \
               -p 8080:8080 \
               --restart unless-stopped \
               -e SPRING_PROFILES_ACTIVE=prod \
-              -e DB_URL=${{ secrets.DB_URL }} \
+              -e DB_URL=jdbc:mysql://aidom-mysql:3306/${{ secrets.DB_NAME }} \
               -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
               -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
-              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+              $NEW_IMAGE
+
+            # Health check: 최대 30초 대기, 5초 간격
+            OK=false
+            for i in $(seq 1 6); do
+              if curl -sf http://localhost:8080/actuator/health; then
+                OK=true
+                break
+              fi
+              sleep 5
+            done
+
+            if [ "$OK" = false ]; then
+              echo "Health check failed, rolling back..."
+              docker stop aidom-backend || true
+              docker rm aidom-backend || true
+              if [ -n "$PREV_IMAGE" ]; then
+                docker run -d \
+                  --name aidom-backend \
+                  --network aidom-network \
+                  -p 8080:8080 \
+                  --restart unless-stopped \
+                  -e SPRING_PROFILES_ACTIVE=prod \
+                  -e DB_URL=jdbc:mysql://aidom-mysql:3306/${{ secrets.DB_NAME }} \
+                  -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
+                  -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+                  $PREV_IMAGE
+              fi
+              exit 1
+            fi
+
+            echo "Deploy succeeded: $NEW_IMAGE"
+            docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,3 @@ out/
 
 ### Application Secrets ###
 .env
-src/main/resources/application-local.properties
-src/main/resources/application-prod.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM eclipse-temurin:17-jre-alpine
+RUN apk add --no-cache curl
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8080

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,12 +1,18 @@
 services:
   mysql:
-    image: 'mysql:latest'
+    image: mysql:8.0
+    container_name: aidom-mysql
     env_file:
       - .env
     ports:
       - '3307:3306'
     volumes:
       - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   mysql-data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$MYSQL_ROOT_PASSWORD --silent"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,10 @@
+# Local Development - Docker Compose MySQL
+spring.datasource.url=jdbc:mysql://localhost:3307/aidom
+spring.datasource.username=aidomuser
+spring.datasource.password=aidomsecret
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,13 @@
+# Production - Environment Variable Based
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+# Actuator - health endpoint only
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,3 @@
 spring.application.name=aidom-backend
-spring.profiles.active=local
 
 spring.mvc.problem-details.enabled=true


### PR DESCRIPTION
## 관련 이슈
Closes #4

## 작업 내용
CI/CD 파이프라인 개선 및 운영 환경 Docker MySQL 구성

## 변경 사항
- CD에서 `bootJar` → `build`로 변경하여 배포 전 테스트 재실행
- `latest` 태그 대신 SHA 태그 기반으로 명시적 배포
- actuator health check 추가 (최대 30초 대기)
- health check 실패 시 이전 이미지로 자동 롤백
- Docker 네트워크 기반 MySQL 컨테이너 운영 구성
- `compose.yaml` MySQL 8.0 버전 고정, healthcheck 추가
- `Dockerfile`에 health check용 curl 추가
- `spring-boot-starter-actuator` 의존성 추가
- `application.properties`에서 `spring.profiles.active=local` 하드코딩 제거

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [ ] 관련 서비스 동작을 확인했는가?

## 테스트
- `./gradlew build` 로컬 빌드 및 테스트 통과 확인

## 리뷰 포인트
- `cd.yml` 배포 스크립트의 MySQL 초기화 및 롤백 흐름
- `application-prod.properties`는 `.gitignore` 대상이라 actuator 설정(`management.endpoints.web.exposure.include=health`)은 운영 서버에 직접 반영 필요