### PR TITLE
feat(entity): Facility·VisitHistory·Bookmark 엔티티 완성

### DIFF
--- a/src/main/java/com/aidom/api/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/aidom/api/domain/bookmark/entity/Bookmark.java
@@ -4,13 +4,18 @@ import com.aidom.api.domain.facility.entity.Facility;
 import com.aidom.api.domain.user.entity.User;
 import com.aidom.api.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import java.util.Objects;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "bookmarks")
+@Table(
+    name = "bookmarks",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uk_bookmark_user_facility",
+            columnNames = {"user_id", "facility_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AttributeOverride(name = "id", column = @Column(name = "bookmark_id"))
@@ -24,9 +29,24 @@ public class Bookmark extends BaseEntity {
   @JoinColumn(name = "facility_id", nullable = false)
   private Facility facility;
 
-  @Builder
   private Bookmark(User user, Facility facility) {
     this.user = user;
     this.facility = facility;
+  }
+
+  public static Bookmark of(User user, Facility facility) {
+    return new Bookmark(user, facility);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Bookmark bookmark)) return false;
+    return getId() != null && getId().equals(bookmark.getId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getId());
   }
 }

--- a/src/main/java/com/aidom/api/domain/facility/entity/Facility.java
+++ b/src/main/java/com/aidom/api/domain/facility/entity/Facility.java
@@ -1,17 +1,170 @@
 package com.aidom.api.domain.facility.entity;
 
+import com.aidom.api.domain.facility.enums.ServiceType;
 import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "facilities")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Facility {
 
   @Id
   @Column(name = "facility_id", length = 20)
   private String id;
+
+  @Column(name = "facility_name", nullable = false)
+  private String facilityName;
+
+  @Column(name = "service_type_code", nullable = false, length = 20)
+  private String serviceTypeCode;
+
+  @Column(name = "service_type", nullable = false)
+  private ServiceType serviceType;
+
+  @Column(name = "district_code", nullable = false, length = 10)
+  private String districtCode;
+
+  @Column(name = "district_name", nullable = false, length = 50)
+  private String districtName;
+
+  @Column(columnDefinition = "TEXT")
+  private String address;
+
+  @Column(precision = 10, scale = 7)
+  private BigDecimal lat;
+
+  @Column(precision = 10, scale = 7)
+  private BigDecimal lng;
+
+  @Column(name = "age_group", nullable = false, length = 50)
+  private String ageGroup;
+
+  @Column(name = "age_min", nullable = false)
+  private int ageMin;
+
+  @Column(name = "age_max", nullable = false)
+  private int ageMax;
+
+  @Column(name = "booking_required", nullable = false)
+  private boolean bookingRequired;
+
+  @Column(name = "is_free", nullable = false)
+  private boolean isFree;
+
+  private Integer fee;
+
+  @Column(name = "monthly_fee")
+  private Integer monthlyFee;
+
+  @Column(name = "capacity_regular")
+  private Integer capacityRegular;
+
+  @Column(name = "capacity_temporary")
+  private Integer capacityTemporary;
+
+  @Column(name = "area_sqm", precision = 10, scale = 2)
+  private BigDecimal areaSqm;
+
+  @Column(name = "operating_days", columnDefinition = "TEXT")
+  private String operatingDays;
+
+  @Column(name = "closed_days", columnDefinition = "TEXT")
+  private String closedDays;
+
+  @Column(name = "has_regular_program", nullable = false)
+  private boolean hasRegularProgram;
+
+  @Column(name = "has_regular_care", nullable = false)
+  private boolean hasRegularCare;
+
+  @Column(name = "has_temporary_care", nullable = false)
+  private boolean hasTemporaryCare;
+
+  @OneToOne(mappedBy = "facility", fetch = FetchType.LAZY)
+  private FacilityExternalInfo externalInfo;
+
+  @OneToOne(mappedBy = "facility", fetch = FetchType.LAZY)
+  private FacilityStats stats;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate private LocalDateTime updatedAt;
+
+  @Builder
+  private Facility(
+      String id,
+      String facilityName,
+      String serviceTypeCode,
+      ServiceType serviceType,
+      String districtCode,
+      String districtName,
+      String address,
+      BigDecimal lat,
+      BigDecimal lng,
+      String ageGroup,
+      int ageMin,
+      int ageMax,
+      boolean bookingRequired,
+      boolean isFree,
+      Integer fee,
+      Integer monthlyFee,
+      Integer capacityRegular,
+      Integer capacityTemporary,
+      BigDecimal areaSqm,
+      String operatingDays,
+      String closedDays,
+      boolean hasRegularProgram,
+      boolean hasRegularCare,
+      boolean hasTemporaryCare) {
+    this.id = id;
+    this.facilityName = facilityName;
+    this.serviceTypeCode = serviceTypeCode;
+    this.serviceType = serviceType;
+    this.districtCode = districtCode;
+    this.districtName = districtName;
+    this.address = address;
+    this.lat = lat;
+    this.lng = lng;
+    this.ageGroup = ageGroup;
+    this.ageMin = ageMin;
+    this.ageMax = ageMax;
+    this.bookingRequired = bookingRequired;
+    this.isFree = isFree;
+    this.fee = fee;
+    this.monthlyFee = monthlyFee;
+    this.capacityRegular = capacityRegular;
+    this.capacityTemporary = capacityTemporary;
+    this.areaSqm = areaSqm;
+    this.operatingDays = operatingDays;
+    this.closedDays = closedDays;
+    this.hasRegularProgram = hasRegularProgram;
+    this.hasRegularCare = hasRegularCare;
+    this.hasTemporaryCare = hasTemporaryCare;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Facility facility)) return false;
+    return id != null && id.equals(facility.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
 }

--- a/src/main/java/com/aidom/api/domain/facility/entity/FacilityExternalInfo.java
+++ b/src/main/java/com/aidom/api/domain/facility/entity/FacilityExternalInfo.java
@@ -34,11 +34,11 @@ public class FacilityExternalInfo {
   @Column(length = 20)
   private String businessStatus;
 
-  /** null이면 Facility.address로 fallback **/
+  /** null이면 Facility.address로 fallback * */
   @Column(length = 300)
   private String naverAddress;
 
-  /** null이면 Facility의 fee/monthly_fee로 fallback. **/
+  /** null이면 Facility의 fee/monthly_fee로 fallback. * */
   @Column(columnDefinition = "TEXT")
   private String feeText;
 

--- a/src/main/java/com/aidom/api/domain/facility/entity/FacilityStats.java
+++ b/src/main/java/com/aidom/api/domain/facility/entity/FacilityStats.java
@@ -1,0 +1,96 @@
+package com.aidom.api.domain.facility.entity;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "facility_stats")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FacilityStats {
+
+  @Id
+  @Column(name = "facility_id", length = 20)
+  private String facilityId;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @MapsId
+  @JoinColumn(name = "facility_id")
+  private Facility facility;
+
+  @Column(name = "avg_rating", nullable = false, precision = 2, scale = 1)
+  private BigDecimal avgRating;
+
+  @Column(name = "avg_rating_safety", nullable = false, precision = 2, scale = 1)
+  private BigDecimal avgRatingSafety;
+
+  @Column(name = "avg_rating_cleanliness", nullable = false, precision = 2, scale = 1)
+  private BigDecimal avgRatingCleanliness;
+
+  @Column(name = "avg_rating_management", nullable = false, precision = 2, scale = 1)
+  private BigDecimal avgRatingManagement;
+
+  @Column(name = "avg_rating_kindness", nullable = false, precision = 2, scale = 1)
+  private BigDecimal avgRatingKindness;
+
+  @Column(name = "review_count", nullable = false)
+  private int reviewCount;
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Builder
+  private FacilityStats(
+      Facility facility,
+      BigDecimal avgRating,
+      BigDecimal avgRatingSafety,
+      BigDecimal avgRatingCleanliness,
+      BigDecimal avgRatingManagement,
+      BigDecimal avgRatingKindness,
+      int reviewCount) {
+    this.facility = facility;
+    this.avgRating = avgRating;
+    this.avgRatingSafety = avgRatingSafety;
+    this.avgRatingCleanliness = avgRatingCleanliness;
+    this.avgRatingManagement = avgRatingManagement;
+    this.avgRatingKindness = avgRatingKindness;
+    this.reviewCount = reviewCount;
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  /** 리뷰 집계 결과로 통계를 재계산한다. */
+  public void recalculate(
+      BigDecimal avgRating,
+      BigDecimal avgRatingSafety,
+      BigDecimal avgRatingCleanliness,
+      BigDecimal avgRatingManagement,
+      BigDecimal avgRatingKindness,
+      int reviewCount) {
+    this.avgRating = avgRating.setScale(1, RoundingMode.HALF_UP);
+    this.avgRatingSafety = avgRatingSafety.setScale(1, RoundingMode.HALF_UP);
+    this.avgRatingCleanliness = avgRatingCleanliness.setScale(1, RoundingMode.HALF_UP);
+    this.avgRatingManagement = avgRatingManagement.setScale(1, RoundingMode.HALF_UP);
+    this.avgRatingKindness = avgRatingKindness.setScale(1, RoundingMode.HALF_UP);
+    this.reviewCount = reviewCount;
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof FacilityStats that)) return false;
+    return facilityId != null && facilityId.equals(that.facilityId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(facilityId);
+  }
+}

--- a/src/main/java/com/aidom/api/domain/facility/entity/FacilityStats.java
+++ b/src/main/java/com/aidom/api/domain/facility/entity/FacilityStats.java
@@ -56,11 +56,11 @@ public class FacilityStats {
       BigDecimal avgRatingKindness,
       int reviewCount) {
     this.facility = facility;
-    this.avgRating = avgRating;
-    this.avgRatingSafety = avgRatingSafety;
-    this.avgRatingCleanliness = avgRatingCleanliness;
-    this.avgRatingManagement = avgRatingManagement;
-    this.avgRatingKindness = avgRatingKindness;
+    this.avgRating = normalizeRating(avgRating);
+    this.avgRatingSafety = normalizeRating(avgRatingSafety);
+    this.avgRatingCleanliness = normalizeRating(avgRatingCleanliness);
+    this.avgRatingManagement = normalizeRating(avgRatingManagement);
+    this.avgRatingKindness = normalizeRating(avgRatingKindness);
     this.reviewCount = reviewCount;
     this.updatedAt = LocalDateTime.now();
   }
@@ -73,13 +73,18 @@ public class FacilityStats {
       BigDecimal avgRatingManagement,
       BigDecimal avgRatingKindness,
       int reviewCount) {
-    this.avgRating = avgRating.setScale(1, RoundingMode.HALF_UP);
-    this.avgRatingSafety = avgRatingSafety.setScale(1, RoundingMode.HALF_UP);
-    this.avgRatingCleanliness = avgRatingCleanliness.setScale(1, RoundingMode.HALF_UP);
-    this.avgRatingManagement = avgRatingManagement.setScale(1, RoundingMode.HALF_UP);
-    this.avgRatingKindness = avgRatingKindness.setScale(1, RoundingMode.HALF_UP);
+    this.avgRating = normalizeRating(avgRating);
+    this.avgRatingSafety = normalizeRating(avgRatingSafety);
+    this.avgRatingCleanliness = normalizeRating(avgRatingCleanliness);
+    this.avgRatingManagement = normalizeRating(avgRatingManagement);
+    this.avgRatingKindness = normalizeRating(avgRatingKindness);
     this.reviewCount = reviewCount;
     this.updatedAt = LocalDateTime.now();
+  }
+
+  private static BigDecimal normalizeRating(BigDecimal value) {
+    return Objects.requireNonNull(value, "rating must not be null")
+        .setScale(1, RoundingMode.HALF_UP);
   }
 
   @Override

--- a/src/main/java/com/aidom/api/domain/facility/enums/ServiceType.java
+++ b/src/main/java/com/aidom/api/domain/facility/enums/ServiceType.java
@@ -1,0 +1,49 @@
+package com.aidom.api.domain.facility.enums;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ServiceType {
+  CHILD_CENTER("지역아동센터"),
+  KIUM_CENTER("우리동네키움센터"),
+  KIDS_CAFE("서울형키즈카페"),
+  SHARED_CHILDCARE("공동육아방"),
+  CHILDCARE_SHARING_CENTER("공동육아나눔터"),
+  YOUTH_ACADEMY("청소년방과후아카데미");
+
+  private final String description;
+
+  private static final Map<String, ServiceType> BY_DESCRIPTION =
+      Arrays.stream(values())
+          .collect(Collectors.toMap(ServiceType::getDescription, Function.identity()));
+
+  public static ServiceType fromDescription(String description) {
+    ServiceType type = BY_DESCRIPTION.get(description);
+    if (type == null) {
+      throw new IllegalArgumentException("Unknown ServiceType description: " + description);
+    }
+    return type;
+  }
+
+  @Converter(autoApply = true)
+  public static class ServiceTypeConverter implements AttributeConverter<ServiceType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ServiceType attribute) {
+      return attribute == null ? null : attribute.getDescription();
+    }
+
+    @Override
+    public ServiceType convertToEntityAttribute(String dbData) {
+      return dbData == null ? null : ServiceType.fromDescription(dbData);
+    }
+  }
+}

--- a/src/main/java/com/aidom/api/domain/visit/entity/VisitHistory.java
+++ b/src/main/java/com/aidom/api/domain/visit/entity/VisitHistory.java
@@ -43,6 +43,7 @@ public class VisitHistory extends BaseEntity {
   @Column(nullable = false)
   private VisitSource source;
 
+  @Column(name = "reservation_date")
   private LocalDate reservationDate;
 
   private LocalTime startTime;

--- a/src/main/java/com/aidom/api/domain/visit/entity/VisitHistory.java
+++ b/src/main/java/com/aidom/api/domain/visit/entity/VisitHistory.java
@@ -10,13 +10,16 @@ import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "visit_histories")
 @Getter
-@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AttributeOverride(name = "id", column = @Column(name = "visit_id"))
 public class VisitHistory extends BaseEntity {
 
@@ -40,9 +43,7 @@ public class VisitHistory extends BaseEntity {
   @Column(nullable = false)
   private VisitSource source;
 
-  /** 로직 확인 후 수정 예정 **/
-  @Column(nullable = false)
-  private LocalDate visitDate;
+  private LocalDate reservationDate;
 
   private LocalTime startTime;
 
@@ -51,4 +52,46 @@ public class VisitHistory extends BaseEntity {
   private LocalDateTime confirmedAt;
 
   private LocalDateTime cancelledAt;
+
+  @Builder
+  private VisitHistory(
+      User user,
+      Child child,
+      Facility facility,
+      VisitStatus status,
+      VisitSource source,
+      LocalDate reservationDate,
+      LocalTime startTime,
+      LocalTime endTime) {
+    this.user = user;
+    this.child = child;
+    this.facility = facility;
+    this.status = status;
+    this.source = source;
+    this.reservationDate = reservationDate;
+    this.startTime = startTime;
+    this.endTime = endTime;
+  }
+
+  public void confirm() {
+    this.status = VisitStatus.CONFIRMED;
+    this.confirmedAt = LocalDateTime.now();
+  }
+
+  public void cancel() {
+    this.status = VisitStatus.CANCELLED;
+    this.cancelledAt = LocalDateTime.now();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof VisitHistory that)) return false;
+    return getId() != null && getId().equals(that.getId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getId());
+  }
 }


### PR DESCRIPTION
## Summary
- ServiceType enum 신규 생성 (영어 이름 + `@Converter`로 DB 한글 ENUM 값 자동 변환)
- Facility 엔티티 전면 재작성 (DDL 전체 필드 매핑, 직접 auditing, `@OneToOne(mappedBy)` 양방향 관계)
- FacilityStats 신규 생성 (`@MapsId` 패턴, BigDecimal 평점 5종 + `recalculate()`)
- VisitHistory 보강 (`visitDate` → `reservationDate`(nullable), `@Builder`, `confirm()`/`cancel()` 도메인 메서드, equals/hashCode)
- Bookmark 보강 (unique 제약조건, 정적 팩토리 `of(User, Facility)`, equals/hashCode)

## Test plan
- [ ] `./gradlew spotlessApply && ./gradlew compileJava` 성공 확인
- [ ] H2 기반 통합 테스트에서 DDL 자동 생성 검증
- [ ] ServiceType Converter가 한글 ENUM 값을 정상 변환하는지 확인