### PR TITLE
chore: API 공통 인프라 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ out/
 
 ### Application Secrets ###
 .env
+
+### Screenshots ###
+*.png
+*.jpg
+*.jpeg

--- a/src/main/java/com/aidom/api/global/common/dto/PageResponse.java
+++ b/src/main/java/com/aidom/api/global/common/dto/PageResponse.java
@@ -1,0 +1,23 @@
+package com.aidom.api.global.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+@Schema(description = "페이지네이션 응답")
+public record PageResponse<T>(
+    @Schema(description = "데이터 목록") List<T> content,
+    @Schema(description = "현재 페이지 번호 (0-based)", example = "0") int page,
+    @Schema(description = "페이지 크기", example = "20") int size,
+    @Schema(description = "전체 요소 수", example = "100") long totalElements,
+    @Schema(description = "전체 페이지 수", example = "5") int totalPages) {
+
+  public static <T> PageResponse<T> from(Page<T> page) {
+    return new PageResponse<>(
+        page.getContent(),
+        page.getNumber(),
+        page.getSize(),
+        page.getTotalElements(),
+        page.getTotalPages());
+  }
+}

--- a/src/main/java/com/aidom/api/global/common/dto/SliceResponse.java
+++ b/src/main/java/com/aidom/api/global/common/dto/SliceResponse.java
@@ -1,0 +1,18 @@
+package com.aidom.api.global.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+@Schema(description = "무한스크롤 응답")
+public record SliceResponse<T>(
+    @Schema(description = "데이터 목록") List<T> content,
+    @Schema(description = "현재 페이지 번호 (0-based)", example = "0") int page,
+    @Schema(description = "페이지 크기", example = "20") int size,
+    @Schema(description = "다음 페이지 존재 여부", example = "true") boolean hasNext) {
+
+  public static <T> SliceResponse<T> from(Slice<T> slice) {
+    return new SliceResponse<>(
+        slice.getContent(), slice.getNumber(), slice.getSize(), slice.hasNext());
+  }
+}

--- a/src/main/java/com/aidom/api/global/config/SwaggerConfig.java
+++ b/src/main/java/com/aidom/api/global/config/SwaggerConfig.java
@@ -2,6 +2,8 @@ package com.aidom.api.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.tags.Tag;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,6 +17,11 @@ public class SwaggerConfig {
             new Info()
                 .title("AIDOM Backend API")
                 .version("1.0.0")
-                .description("AIDOM Backend REST API Documentation"));
+                .description("AIDOM Backend REST API Documentation"))
+        .tags(
+            List.of(
+                new Tag().name("시설 Facilities").description("시설 조회·검색·추천·필터 API"),
+                new Tag().name("찜 Bookmarks").description("시설 찜(북마크) API"),
+                new Tag().name("이용내역 Visits").description("시설 이용내역 관리 API")));
   }
 }

--- a/src/main/java/com/aidom/api/global/error/ErrorCode.java
+++ b/src/main/java/com/aidom/api/global/error/ErrorCode.java
@@ -28,7 +28,19 @@ public enum ErrorCode {
   // Validation
   DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "V001", "이미 존재하는 데이터입니다."),
   BUSINESS_VALIDATION_ERROR(
-      HttpStatus.UNPROCESSABLE_ENTITY, "V002", "비즈니스 규칙 위반 또는 처리할 수 없는 요청입니다.");
+      HttpStatus.UNPROCESSABLE_ENTITY, "V002", "비즈니스 규칙 위반 또는 처리할 수 없는 요청입니다."),
+
+  // Facility
+  FACILITY_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "시설을 찾을 수 없습니다."),
+
+  // Bookmark
+  ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "B001", "이미 찜한 시설입니다."),
+  BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "B002", "찜 내역을 찾을 수 없습니다."),
+
+  // Visit
+  VISIT_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "이용 내역을 찾을 수 없습니다."),
+  VISIT_ALREADY_CANCELLED(HttpStatus.UNPROCESSABLE_ENTITY, "T002", "이미 취소된 이용 내역입니다."),
+  VISIT_ALREADY_CONFIRMED(HttpStatus.UNPROCESSABLE_ENTITY, "T003", "이미 확정된 이용 내역입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=aidom-backend
+server.port=8090
 
 spring.mvc.problem-details.enabled=true


### PR DESCRIPTION
## Summary
- .gitignore에 이미지 파일(png, jpg, jpeg) 제외 추가
- 서버 포트 8080 → 8090 변경
- 공통 페이지네이션 응답 DTO 추가 (PageResponse, SliceResponse)
- Swagger 태그 3개 정의 (시설, 찜, 이용내역)
- 도메인별 에러코드 6개 추가 (F001, B001 ~ B002, T001 ~ T003)

## Test plan
- [x] `./gradlew spotlessApply` 통과
- [x] `./gradlew compileJava` 통과
- [x] `./gradlew test` 전체 통과