### PR TITLE
chore: prod DB를 Docker MySQL에서 RDS로 전환

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
+# Local (Docker Compose)
 MYSQL_DATABASE=aidom
 MYSQL_USER=aidomuser
 MYSQL_PASSWORD=aidomsecret
 MYSQL_ROOT_PASSWORD=aidomverysecret
+
+# Production (RDS) - GitHub Secrets로 관리
+# DB_URL=jdbc:mysql://<rds-endpoint>.ap-northeast-2.rds.amazonaws.com:3306/aidom
+# DB_USERNAME=aidomuser
+# DB_PASSWORD=<rds-password>

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,47 +61,6 @@ jobs:
             # GHCR 로그인
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-            # Docker 네트워크 생성 (없으면)
-            docker network create aidom-network 2>/dev/null || true
-
-            # MySQL 컨테이너 관리
-            if ! docker ps -a --format '{{.Names}}' | grep -q '^aidom-mysql$'; then
-              # 컨테이너가 없으면 생성
-              docker run -d \
-                --name aidom-mysql \
-                --network aidom-network \
-                --restart unless-stopped \
-                -v mysql-data:/var/lib/mysql \
-                -e MYSQL_DATABASE=${{ secrets.DB_NAME }} \
-                -e MYSQL_USER=${{ secrets.DB_USERNAME }} \
-                -e MYSQL_PASSWORD=${{ secrets.DB_PASSWORD }} \
-                -e MYSQL_ROOT_PASSWORD=${{ secrets.DB_ROOT_PASSWORD }} \
-                mysql:8.0
-            elif ! docker ps --format '{{.Names}}' | grep -q '^aidom-mysql$'; then
-              # 컨테이너가 존재하지만 멈춰있으면 시작
-              docker start aidom-mysql
-            fi
-
-            # MySQL 준비 대기
-            echo "Waiting for MySQL to be ready..."
-            MYSQL_READY=false
-            for i in $(seq 1 12); do
-              if docker exec aidom-mysql mysqladmin ping -h localhost -u root -p${{ secrets.DB_ROOT_PASSWORD }} --silent 2>/dev/null; then
-                echo "MySQL is ready"
-                MYSQL_READY=true
-                break
-              fi
-              sleep 5
-            done
-
-            if [ "$MYSQL_READY" = false ]; then
-              echo "MySQL failed to start"
-              exit 1
-            fi
-
-            # MySQL 컨테이너가 네트워크에 연결되어 있는지 확인
-            docker network connect aidom-network aidom-mysql 2>/dev/null || true
-
             # 앱 배포
             NEW_IMAGE="${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
             docker pull $NEW_IMAGE
@@ -113,13 +72,12 @@ jobs:
 
             docker run -d \
               --name aidom-backend \
-              --network aidom-network \
               -p 8080:8080 \
               --restart unless-stopped \
               -e SPRING_PROFILES_ACTIVE=prod \
-              -e DB_URL=jdbc:mysql://aidom-mysql:3306/${{ secrets.DB_NAME }} \
-              -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
-              -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+              -e "DB_URL=${{ secrets.DB_URL }}" \
+              -e "DB_USERNAME=${{ secrets.DB_USERNAME }}" \
+              -e "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" \
               $NEW_IMAGE
 
             # Health check: 최대 30초 대기, 5초 간격
@@ -139,13 +97,12 @@ jobs:
               if [ -n "$PREV_IMAGE" ]; then
                 docker run -d \
                   --name aidom-backend \
-                  --network aidom-network \
                   -p 8080:8080 \
                   --restart unless-stopped \
                   -e SPRING_PROFILES_ACTIVE=prod \
-                  -e DB_URL=jdbc:mysql://aidom-mysql:3306/${{ secrets.DB_NAME }} \
-                  -e DB_USERNAME=${{ secrets.DB_USERNAME }} \
-                  -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
+                  -e "DB_URL=${{ secrets.DB_URL }}" \
+                  -e "DB_USERNAME=${{ secrets.DB_USERNAME }}" \
+                  -e "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" \
                   $PREV_IMAGE
               fi
               exit 1

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
-    runtimeOnly 'com.h2database:h2'
+    testRuntimeOnly 'com.h2database:h2'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,6 +4,13 @@ spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+# HikariCP connection pool (RDS)
+spring.datasource.hikari.maximum-pool-size=10
+spring.datasource.hikari.minimum-idle=5
+spring.datasource.hikari.idle-timeout=300000
+spring.datasource.hikari.max-lifetime=1200000
+spring.datasource.hikari.connection-timeout=5000
+
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## Summary
- EC2 배포 시 Docker MySQL 컨테이너 대신 AWS RDS MySQL로 연결하도록 변경
- CD 워크플로에서 MySQL 컨테이너 생성/시작/대기 로직 및 docker network 제거
- `DB_URL`을 GitHub Secrets에서 주입하도록 변경
- HikariCP 커넥션 풀 설정 추가 (prod)
- H2 의존성을 `testRuntimeOnly`로 변경하여 런타임에서 제외

## GitHub Secrets 변경 필요
- `DB_URL` 추가: `jdbc:mysql://<rds-endpoint>:3306/aidom`
- `DB_USERNAME`, `DB_PASSWORD`: RDS 계정 정보로 업데이트
- `DB_ROOT_PASSWORD`: 삭제 가능 (더 이상 불필요)

## Test plan
- [ ] GitHub Secrets에 `DB_URL` 등록
- [ ] main push 후 CD 정상 배포 확인
- [ ] `/actuator/health` 로 RDS 연결 확인
- [ ] 로컬 `local` 프로필로 기존 Docker MySQL 정상 동작 확인