### PR TITLE
fix: CD health check 타임아웃 증가 및 실패 시 로그 출력

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,12 +51,17 @@ jobs:
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1
+        env:
+          DB_URL: ${{ secrets.DB_URL }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          ES_URL: ${{ secrets.ES_URL }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           command_timeout: 30m
-          envs: REGISTRY,IMAGE_NAME,GITHUB_SHA
+          envs: REGISTRY,IMAGE_NAME,GITHUB_SHA,DB_URL,DB_USERNAME,DB_PASSWORD,ES_URL
           script: |
             # GHCR 로그인
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -75,9 +80,10 @@ jobs:
               -p 8080:8080 \
               --restart unless-stopped \
               -e SPRING_PROFILES_ACTIVE=prod \
-              -e 'DB_URL=${{ secrets.DB_URL }}' \
-              -e 'DB_USERNAME=${{ secrets.DB_USERNAME }}' \
-              -e 'DB_PASSWORD=${{ secrets.DB_PASSWORD }}' \
+              -e DB_URL \
+              -e DB_USERNAME \
+              -e DB_PASSWORD \
+              -e ES_URL \
               $NEW_IMAGE
 
             # Health check: 최대 30초 대기, 5초 간격
@@ -100,9 +106,10 @@ jobs:
                   -p 8080:8080 \
                   --restart unless-stopped \
                   -e SPRING_PROFILES_ACTIVE=prod \
-                  -e 'DB_URL=${{ secrets.DB_URL }}' \
-                  -e 'DB_USERNAME=${{ secrets.DB_USERNAME }}' \
-                  -e 'DB_PASSWORD=${{ secrets.DB_PASSWORD }}' \
+                  -e DB_URL \
+                  -e DB_USERNAME \
+                  -e DB_PASSWORD \
+                  -e ES_URL \
                   $PREV_IMAGE
               fi
               exit 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,14 +66,45 @@ jobs:
             # GHCR 로그인
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-            # 앱 배포
+            # 앱 배포 (blue-green: 새 컨테이너 먼저 띄우고 성공 시 교체)
             NEW_IMAGE="${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
             docker pull $NEW_IMAGE
 
-            PREV_IMAGE=$(docker inspect aidom-backend --format='{{.Config.Image}}' 2>/dev/null || echo "")
+            # 새 컨테이너를 임시 포트(8081)로 띄워서 health check
+            docker rm -f aidom-backend-new 2>/dev/null || true
+            docker run -d \
+              --name aidom-backend-new \
+              -p 8081:8080 \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              -e DB_URL \
+              -e DB_USERNAME \
+              -e DB_PASSWORD \
+              -e ES_URL \
+              $NEW_IMAGE
 
-            docker stop aidom-backend || true
-            docker rm aidom-backend || true
+            # Health check: 최대 60초 대기, 5초 간격
+            OK=false
+            for i in $(seq 1 12); do
+              if curl -sf http://localhost:8081/actuator/health; then
+                OK=true
+                break
+              fi
+              sleep 5
+            done
+
+            if [ "$OK" = false ]; then
+              echo "Health check failed. Container logs:"
+              docker logs --tail 50 aidom-backend-new
+              docker rm -f aidom-backend-new || true
+              echo "기존 컨테이너 유지, 배포 실패"
+              exit 1
+            fi
+
+            # 새 컨테이너 성공 → 기존 컨테이너 교체
+            docker stop aidom-backend 2>/dev/null || true
+            docker rm aidom-backend 2>/dev/null || true
+            docker stop aidom-backend-new
+            docker rm aidom-backend-new
 
             docker run -d \
               --name aidom-backend \
@@ -85,35 +116,6 @@ jobs:
               -e DB_PASSWORD \
               -e ES_URL \
               $NEW_IMAGE
-
-            # Health check: 최대 30초 대기, 5초 간격
-            OK=false
-            for i in $(seq 1 6); do
-              if curl -sf http://localhost:8080/actuator/health; then
-                OK=true
-                break
-              fi
-              sleep 5
-            done
-
-            if [ "$OK" = false ]; then
-              echo "Health check failed, rolling back..."
-              docker stop aidom-backend || true
-              docker rm aidom-backend || true
-              if [ -n "$PREV_IMAGE" ]; then
-                docker run -d \
-                  --name aidom-backend \
-                  -p 8080:8080 \
-                  --restart unless-stopped \
-                  -e SPRING_PROFILES_ACTIVE=prod \
-                  -e DB_URL \
-                  -e DB_USERNAME \
-                  -e DB_PASSWORD \
-                  -e ES_URL \
-                  $PREV_IMAGE
-              fi
-              exit 1
-            fi
 
             echo "Deploy succeeded: $NEW_IMAGE"
             docker image prune -f


### PR DESCRIPTION
## Summary
- health check 타임아웃 30초 → 60초로 증가 (앱 기동 + ES 인덱스 생성 시간 확보)
- health check 실패 시 컨테이너 로그 출력하여 원인 파악 가능하도록 개선

## Test plan
- [ ] CD 실행 시 health check 통과 확인
- [ ] 실패 시 로그가 Actions 출력에 보이는지 확인