### PR TITLE
fix: CD 배포 전략을 blue-green으로 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,14 +66,43 @@ jobs:
             # GHCR 로그인
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-            # 앱 배포
+            # 앱 배포 (blue-green: 새 컨테이너 먼저 검증 후 교체)
             NEW_IMAGE="${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}"
             docker pull $NEW_IMAGE
 
-            PREV_IMAGE=$(docker inspect aidom-backend --format='{{.Config.Image}}' 2>/dev/null || echo "")
+            # 새 컨테이너를 임시 포트(8081)로 띄워서 health check
+            docker rm -f aidom-backend-new 2>/dev/null || true
+            docker run -d \
+              --name aidom-backend-new \
+              -p 8081:8080 \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              -e DB_URL \
+              -e DB_USERNAME \
+              -e DB_PASSWORD \
+              -e ES_URL \
+              $NEW_IMAGE
 
-            docker stop aidom-backend || true
-            docker rm aidom-backend || true
+            # Health check: 최대 60초 대기, 5초 간격
+            OK=false
+            for i in $(seq 1 12); do
+              if curl -sf http://localhost:8081/actuator/health; then
+                OK=true
+                break
+              fi
+              sleep 5
+            done
+
+            if [ "$OK" = false ]; then
+              echo "Health check failed. Container logs:"
+              docker logs --tail 50 aidom-backend-new
+              docker rm -f aidom-backend-new || true
+              echo "기존 컨테이너 유지, 배포 실패"
+              exit 1
+            fi
+
+            # 새 컨테이너 검증 성공 → 기존 컨테이너 교체
+            docker rm -f aidom-backend-new
+            docker stop aidom-backend 2>/dev/null && docker rename aidom-backend aidom-backend-old || true
 
             docker run -d \
               --name aidom-backend \
@@ -86,34 +115,26 @@ jobs:
               -e ES_URL \
               $NEW_IMAGE
 
-            # Health check: 최대 30초 대기, 5초 간격
-            OK=false
-            for i in $(seq 1 6); do
+            # 최종 컨테이너(8080) health check
+            FINAL_OK=false
+            for i in $(seq 1 12); do
               if curl -sf http://localhost:8080/actuator/health; then
-                OK=true
+                FINAL_OK=true
                 break
               fi
               sleep 5
             done
 
-            if [ "$OK" = false ]; then
-              echo "Health check failed, rolling back..."
-              docker stop aidom-backend || true
-              docker rm aidom-backend || true
-              if [ -n "$PREV_IMAGE" ]; then
-                docker run -d \
-                  --name aidom-backend \
-                  -p 8080:8080 \
-                  --restart unless-stopped \
-                  -e SPRING_PROFILES_ACTIVE=prod \
-                  -e DB_URL \
-                  -e DB_USERNAME \
-                  -e DB_PASSWORD \
-                  -e ES_URL \
-                  $PREV_IMAGE
-              fi
+            if [ "$FINAL_OK" = false ]; then
+              echo "Final health check failed. Rolling back..."
+              docker logs --tail 50 aidom-backend
+              docker rm -f aidom-backend || true
+              docker rename aidom-backend-old aidom-backend
+              docker start aidom-backend
               exit 1
             fi
 
+            # 배포 성공, 이전 컨테이너 정리
+            docker rm -f aidom-backend-old 2>/dev/null || true
             echo "Deploy succeeded: $NEW_IMAGE"
             docker image prune -f


### PR DESCRIPTION
## Summary
- 새 컨테이너를 임시 포트(8081)로 먼저 띄워 health check 검증
- 성공 시에만 기존 컨테이너 교체, **실패 시 기존 컨테이너 유지 (서비스 다운 방지)**
- health check 타임아웃 30초 → 60초로 증가
- 실패 시 컨테이너 로그를 Actions에 출력하여 디버깅 지원

## Before
기존 컨테이너를 먼저 죽이고 새 컨테이너를 띄우기 때문에, 배포 실패 시 서비스가 완전히 내려감

## After
새 컨테이너가 검증될 때까지 기존 컨테이너가 계속 서비스하므로, 배포 실패해도 서비스 유지

## Test plan
- [ ] CD 실행 시 8081 포트로 health check 후 교체 확인
- [ ] 배포 실패 시 기존 컨테이너가 유지되는지 확인
- [ ] Actions 로그에 실패 원인이 출력되는지 확인