### PR TITLE
feat: 시설 검색 서비스 레이어 구현

### DIFF
--- a/sql/V2__alter_service_type_code_length.sql
+++ b/sql/V2__alter_service_type_code_length.sql
@@ -1,0 +1,5 @@
+-- service_type_code 컬럼 길이를 20 -> 30으로 변경
+-- CHILDCARE_SHARING_CENTER (24자) 등 긴 코드값을 수용하기 위함
+-- 운영 DB에서 ddl-auto=validate 사용 시, 이 스크립트를 먼저 실행해야 합니다.
+
+ALTER TABLE facilities MODIFY COLUMN service_type_code VARCHAR(30) NOT NULL;

--- a/src/main/java/com/aidom/api/domain/facility/controller/FacilityController.java
+++ b/src/main/java/com/aidom/api/domain/facility/controller/FacilityController.java
@@ -1,6 +1,7 @@
 package com.aidom.api.domain.facility.controller;
 
 import com.aidom.api.domain.facility.dto.*;
+import com.aidom.api.domain.facility.service.FacilityService;
 import com.aidom.api.global.common.dto.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,13 +9,23 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.math.BigDecimal;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "시설 Facilities", description = "시설 조회·검색·추천·필터 API")
 @RestController
 @RequestMapping("/api/v1/facilities")
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+    name = "spring.data.elasticsearch.repositories.enabled",
+    havingValue = "true",
+    matchIfMissing = false)
 public class FacilityController {
+
+  private final FacilityService facilityService;
 
   @Operation(summary = "시설 목록 조회", description = "필터 조건에 따른 시설 목록을 페이지네이션으로 조회합니다.")
   @ApiResponse(responseCode = "200", description = "조회 성공")
@@ -22,7 +33,7 @@ public class FacilityController {
   public ResponseEntity<PageResponse<FacilityListResponse>> getFacilities(
       @Parameter(description = "자치구명", example = "강남구") @RequestParam(required = false)
           String districtName,
-      @Parameter(description = "서비스 유형", example = "KIUM_CENTER") @RequestParam(required = false)
+      @Parameter(description = "서비스 유형", example = "우리동네키움센터") @RequestParam(required = false)
           String serviceType,
       @Parameter(description = "무료 여부") @RequestParam(required = false) Boolean isFree,
       @Parameter(description = "최소 연령", example = "6") @RequestParam(required = false)
@@ -35,10 +46,28 @@ public class FacilityController {
           BigDecimal lng,
       @Parameter(description = "반경(km)", example = "3.0") @RequestParam(required = false)
           BigDecimal radius,
+      @Parameter(description = "돌봄 유형 (TEMPORARY/REGULAR)", example = "TEMPORARY")
+          @RequestParam(required = false)
+          String careType,
+      @Parameter(description = "정기 프로그램 여부") @RequestParam(required = false)
+          Boolean hasRegularProgram,
       @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,
       @Parameter(description = "페이지 크기", example = "20") @RequestParam(defaultValue = "20")
           int size) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return ResponseEntity.ok(
+        PageResponse.from(
+            facilityService.listFacilities(
+                districtName,
+                serviceType,
+                isFree,
+                ageMin,
+                ageMax,
+                lat,
+                lng,
+                radius,
+                careType,
+                hasRegularProgram,
+                PageRequest.of(page, size))));
   }
 
   @Operation(summary = "시설 검색", description = "키워드로 시설을 검색합니다. (Elasticsearch)")
@@ -50,7 +79,8 @@ public class FacilityController {
       @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,
       @Parameter(description = "페이지 크기", example = "20") @RequestParam(defaultValue = "20")
           int size) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return ResponseEntity.ok(
+        PageResponse.from(facilityService.searchFacilities(keyword, PageRequest.of(page, size))));
   }
 
   @Operation(summary = "시설 상세 조회", description = "시설 ID로 상세 정보를 조회합니다.")
@@ -60,7 +90,7 @@ public class FacilityController {
   public ResponseEntity<FacilityDetailResponse> getFacility(
       @Parameter(description = "시설 ID", required = true, example = "FAC001") @PathVariable
           String facilityId) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return ResponseEntity.ok(facilityService.getFacility(facilityId));
   }
 
   @Operation(summary = "AI 시설 추천", description = "아이 정보와 위치 기반으로 시설을 추천합니다.")
@@ -74,7 +104,7 @@ public class FacilityController {
           BigDecimal lng,
       @Parameter(description = "최대 결과 수", example = "5") @RequestParam(defaultValue = "5")
           int limit) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return ResponseEntity.ok(facilityService.recommendFacilities(childId, lat, lng, limit));
   }
 
   @Operation(summary = "주변 시설 조회", description = "현재 위치 기반으로 주변 시설을 조회합니다.")
@@ -89,13 +119,13 @@ public class FacilityController {
           BigDecimal radius,
       @Parameter(description = "최대 결과 수", example = "10") @RequestParam(defaultValue = "10")
           int limit) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return ResponseEntity.ok(facilityService.getNearbyFacilities(lat, lng, radius, limit));
   }
 
   @Operation(summary = "필터 옵션 조회", description = "시설 목록 필터에 사용할 옵션(서비스유형, 자치구, 연령대, 돌봄유형)을 조회합니다.")
   @ApiResponse(responseCode = "200", description = "조회 성공")
   @GetMapping("/filters")
   public ResponseEntity<FacilityFilterResponse> getFilters() {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return ResponseEntity.ok(facilityService.getFilters());
   }
 }

--- a/src/main/java/com/aidom/api/domain/facility/controller/FacilityController.java
+++ b/src/main/java/com/aidom/api/domain/facility/controller/FacilityController.java
@@ -1,24 +1,37 @@
 package com.aidom.api.domain.facility.controller;
 
-import com.aidom.api.domain.facility.dto.*;
+import com.aidom.api.domain.facility.dto.FacilityDetailResponse;
+import com.aidom.api.domain.facility.dto.FacilityFilterResponse;
+import com.aidom.api.domain.facility.dto.FacilityListResponse;
+import com.aidom.api.domain.facility.dto.FacilityRecommendResponse;
+import com.aidom.api.domain.facility.dto.FacilitySearchResponse;
 import com.aidom.api.domain.facility.service.FacilityService;
 import com.aidom.api.global.common.dto.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.math.BigDecimal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "시설 Facilities", description = "시설 조회·검색·추천·필터 API")
 @RestController
 @RequestMapping("/api/v1/facilities")
 @RequiredArgsConstructor
+@Validated
 @ConditionalOnProperty(
     name = "spring.data.elasticsearch.repositories.enabled",
     havingValue = "true",
@@ -51,8 +64,14 @@ public class FacilityController {
           String careType,
       @Parameter(description = "정기 프로그램 여부") @RequestParam(required = false)
           Boolean hasRegularProgram,
-      @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,
-      @Parameter(description = "페이지 크기", example = "20") @RequestParam(defaultValue = "20")
+      @Parameter(description = "페이지 번호", example = "0")
+          @PositiveOrZero(message = "페이지 번호는 0 이상이어야 합니다.")
+          @RequestParam(defaultValue = "0")
+          int page,
+      @Parameter(description = "페이지 크기", example = "20")
+          @RequestParam(defaultValue = "20")
+          @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+          @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다.")
           int size) {
     return ResponseEntity.ok(
         PageResponse.from(
@@ -76,8 +95,14 @@ public class FacilityController {
   public ResponseEntity<PageResponse<FacilitySearchResponse>> searchFacilities(
       @Parameter(description = "검색 키워드", required = true, example = "키움센터") @RequestParam
           String keyword,
-      @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,
-      @Parameter(description = "페이지 크기", example = "20") @RequestParam(defaultValue = "20")
+      @Parameter(description = "페이지 번호", example = "0")
+          @PositiveOrZero(message = "페이지 번호는 0 이상이어야 합니다.")
+          @RequestParam(defaultValue = "0")
+          int page,
+      @Parameter(description = "페이지 크기", example = "20")
+          @RequestParam(defaultValue = "20")
+          @Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
+          @Max(value = 100, message = "페이지 크기는 100 이하여야 합니다.")
           int size) {
     return ResponseEntity.ok(
         PageResponse.from(facilityService.searchFacilities(keyword, PageRequest.of(page, size))));
@@ -102,7 +127,10 @@ public class FacilityController {
           BigDecimal lat,
       @Parameter(description = "경도", example = "127.0473") @RequestParam(required = false)
           BigDecimal lng,
-      @Parameter(description = "최대 결과 수", example = "5") @RequestParam(defaultValue = "5")
+      @Parameter(description = "최대 결과 수", example = "5")
+          @RequestParam(defaultValue = "5")
+          @Min(value = 1, message = "최대 결과 수는 1 이상이어야 합니다.")
+          @Max(value = 100, message = "최대 결과 수는 100 이하여야 합니다.")
           int limit) {
     return ResponseEntity.ok(facilityService.recommendFacilities(childId, lat, lng, limit));
   }
@@ -117,7 +145,10 @@ public class FacilityController {
           BigDecimal lng,
       @Parameter(description = "반경(km)", example = "3.0") @RequestParam(defaultValue = "3.0")
           BigDecimal radius,
-      @Parameter(description = "최대 결과 수", example = "10") @RequestParam(defaultValue = "10")
+      @Parameter(description = "최대 결과 수", example = "10")
+          @RequestParam(defaultValue = "10")
+          @Min(value = 1, message = "최대 결과 수는 1 이상이어야 합니다.")
+          @Max(value = 100, message = "최대 결과 수는 100 이하여야 합니다.")
           int limit) {
     return ResponseEntity.ok(facilityService.getNearbyFacilities(lat, lng, radius, limit));
   }

--- a/src/main/java/com/aidom/api/domain/facility/document/FacilityDocument.java
+++ b/src/main/java/com/aidom/api/domain/facility/document/FacilityDocument.java
@@ -54,6 +54,9 @@ public class FacilityDocument {
   @Field(type = FieldType.Boolean)
   private boolean hasTemporaryCare;
 
+  @Field(type = FieldType.Boolean)
+  private boolean hasRegularProgram;
+
   @Field(type = FieldType.Float)
   private float avgRating;
 
@@ -71,6 +74,7 @@ public class FacilityDocument {
       boolean bookingRequired,
       boolean hasRegularCare,
       boolean hasTemporaryCare,
+      boolean hasRegularProgram,
       float avgRating) {
     this.id = id;
     this.facilityName = facilityName;
@@ -84,6 +88,7 @@ public class FacilityDocument {
     this.bookingRequired = bookingRequired;
     this.hasRegularCare = hasRegularCare;
     this.hasTemporaryCare = hasTemporaryCare;
+    this.hasRegularProgram = hasRegularProgram;
     this.avgRating = avgRating;
   }
 }

--- a/src/main/java/com/aidom/api/domain/facility/document/FacilityDocumentMapper.java
+++ b/src/main/java/com/aidom/api/domain/facility/document/FacilityDocumentMapper.java
@@ -23,6 +23,7 @@ public final class FacilityDocumentMapper {
         .bookingRequired(facility.isBookingRequired())
         .hasRegularCare(facility.isHasRegularCare())
         .hasTemporaryCare(facility.isHasTemporaryCare())
+        .hasRegularProgram(facility.isHasRegularProgram())
         .avgRating(extractAvgRating(facility.getStats()))
         .build();
   }

--- a/src/main/java/com/aidom/api/domain/facility/entity/Facility.java
+++ b/src/main/java/com/aidom/api/domain/facility/entity/Facility.java
@@ -27,7 +27,7 @@ public class Facility {
   @Column(name = "facility_name", nullable = false)
   private String facilityName;
 
-  @Column(name = "service_type_code", nullable = false, length = 20)
+  @Column(name = "service_type_code", nullable = false, length = 30)
   private String serviceTypeCode;
 
   @Column(name = "service_type", nullable = false)

--- a/src/main/java/com/aidom/api/domain/facility/repository/FacilityRepository.java
+++ b/src/main/java/com/aidom/api/domain/facility/repository/FacilityRepository.java
@@ -1,0 +1,6 @@
+package com.aidom.api.domain.facility.repository;
+
+import com.aidom.api.domain.facility.entity.Facility;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FacilityRepository extends JpaRepository<Facility, String> {}

--- a/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepository.java
+++ b/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepository.java
@@ -1,10 +1,31 @@
 package com.aidom.api.domain.facility.repository;
 
 import com.aidom.api.domain.facility.document.FacilityDocument;
+import java.math.BigDecimal;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface FacilitySearchCustomRepository {
 
   Page<FacilityDocument> searchByFacilityName(String keyword, Pageable pageable);
+
+  Page<FacilityDocument> searchWithFilters(
+      String districtName,
+      String serviceType,
+      Boolean isFree,
+      Integer ageMin,
+      Integer ageMax,
+      BigDecimal lat,
+      BigDecimal lng,
+      BigDecimal radius,
+      String careType,
+      Boolean hasRegularProgram,
+      Pageable pageable);
+
+  List<FacilityDocument> searchNearby(double lat, double lng, double radiusKm, int limit);
+
+  List<FacilityDocument> recommendByChildAge(int childAge, Double lat, Double lng, int limit);
+
+  List<String> getDistinctDistrictNames();
 }

--- a/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepositoryImpl.java
+++ b/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepositoryImpl.java
@@ -87,7 +87,7 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
                                                     ll ->
                                                         ll.lat(lat.doubleValue())
                                                             .lon(lng.doubleValue())))
-                                        .distance(radius + "km")
+                                        .distance(radius.toPlainString() + "km")
                                         .distanceType(GeoDistanceType.Arc)));
                   }
                   if ("TEMPORARY".equals(careType)) {

--- a/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepositoryImpl.java
+++ b/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepositoryImpl.java
@@ -1,12 +1,21 @@
 package com.aidom.api.domain.facility.repository;
 
+import co.elastic.clients.elasticsearch._types.GeoDistanceType;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionBoostMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreMode;
 import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
 import com.aidom.api.domain.facility.document.FacilityDocument;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHitSupport;
 import org.springframework.data.elasticsearch.core.SearchHits;
 
@@ -27,5 +36,240 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
     SearchHits<FacilityDocument> hits = operations.search(query, FacilityDocument.class);
 
     return SearchHitSupport.searchPageFor(hits, pageable).map(searchHit -> searchHit.getContent());
+  }
+
+  @Override
+  public Page<FacilityDocument> searchWithFilters(
+      String districtName,
+      String serviceType,
+      Boolean isFree,
+      Integer ageMin,
+      Integer ageMax,
+      BigDecimal lat,
+      BigDecimal lng,
+      BigDecimal radius,
+      String careType,
+      Boolean hasRegularProgram,
+      Pageable pageable) {
+
+    var builder = NativeQuery.builder();
+
+    builder.withQuery(
+        q ->
+            q.bool(
+                b -> {
+                  if (districtName != null) {
+                    b.filter(f -> f.term(t -> t.field("districtName").value(districtName)));
+                  }
+                  if (serviceType != null) {
+                    b.filter(f -> f.term(t -> t.field("serviceType").value(serviceType)));
+                  }
+                  if (isFree != null) {
+                    b.filter(f -> f.term(t -> t.field("isFree").value(isFree)));
+                  }
+                  if (ageMin != null) {
+                    b.filter(
+                        f -> f.range(r -> r.number(n -> n.field("ageMax").gte((double) ageMin))));
+                  }
+                  if (ageMax != null) {
+                    b.filter(
+                        f -> f.range(r -> r.number(n -> n.field("ageMin").lte((double) ageMax))));
+                  }
+                  if (lat != null && lng != null && radius != null) {
+                    b.filter(
+                        f ->
+                            f.geoDistance(
+                                g ->
+                                    g.field("location")
+                                        .location(
+                                            l ->
+                                                l.latlon(
+                                                    ll ->
+                                                        ll.lat(lat.doubleValue())
+                                                            .lon(lng.doubleValue())))
+                                        .distance(radius + "km")
+                                        .distanceType(GeoDistanceType.Arc)));
+                  }
+                  if ("TEMPORARY".equals(careType)) {
+                    b.filter(f -> f.term(t -> t.field("hasTemporaryCare").value(true)));
+                  } else if ("REGULAR".equals(careType)) {
+                    b.filter(f -> f.term(t -> t.field("hasRegularCare").value(true)));
+                  }
+                  if (hasRegularProgram != null) {
+                    b.filter(
+                        f -> f.term(t -> t.field("hasRegularProgram").value(hasRegularProgram)));
+                  }
+                  return b;
+                }));
+
+    if (lat != null && lng != null) {
+      builder.withSort(
+          s ->
+              s.geoDistance(
+                  g ->
+                      g.field("location")
+                          .location(
+                              l -> l.latlon(ll -> ll.lat(lat.doubleValue()).lon(lng.doubleValue())))
+                          .order(SortOrder.Asc)
+                          .unit(co.elastic.clients.elasticsearch._types.DistanceUnit.Kilometers)));
+    }
+
+    builder.withPageable(pageable);
+
+    NativeQuery query = builder.build();
+    SearchHits<FacilityDocument> hits = operations.search(query, FacilityDocument.class);
+
+    return SearchHitSupport.searchPageFor(hits, pageable).map(searchHit -> searchHit.getContent());
+  }
+
+  @Override
+  public List<FacilityDocument> searchNearby(double lat, double lng, double radiusKm, int limit) {
+    NativeQuery query =
+        NativeQuery.builder()
+            .withQuery(
+                q ->
+                    q.bool(
+                        b ->
+                            b.filter(
+                                f ->
+                                    f.geoDistance(
+                                        g ->
+                                            g.field("location")
+                                                .location(l -> l.latlon(ll -> ll.lat(lat).lon(lng)))
+                                                .distance(radiusKm + "km")
+                                                .distanceType(GeoDistanceType.Arc)))))
+            .withSort(
+                s ->
+                    s.geoDistance(
+                        g ->
+                            g.field("location")
+                                .location(l -> l.latlon(ll -> ll.lat(lat).lon(lng)))
+                                .order(SortOrder.Asc)
+                                .unit(
+                                    co.elastic.clients.elasticsearch._types.DistanceUnit
+                                        .Kilometers)))
+            .withPageable(PageRequest.of(0, limit))
+            .build();
+
+    SearchHits<FacilityDocument> hits = operations.search(query, FacilityDocument.class);
+
+    return hits.getSearchHits().stream().map(SearchHit::getContent).toList();
+  }
+
+  @Override
+  public List<FacilityDocument> recommendByChildAge(
+      int childAge, Double lat, Double lng, int limit) {
+
+    NativeQuery query =
+        NativeQuery.builder()
+            .withQuery(
+                q ->
+                    q.functionScore(
+                        fs -> {
+                          fs.query(
+                              mq ->
+                                  mq.bool(
+                                      b ->
+                                          b.filter(
+                                                  f ->
+                                                      f.range(
+                                                          r ->
+                                                              r.number(
+                                                                  n ->
+                                                                      n.field("ageMin")
+                                                                          .lte((double) childAge))))
+                                              .filter(
+                                                  f ->
+                                                      f.range(
+                                                          r ->
+                                                              r.number(
+                                                                  n ->
+                                                                      n.field("ageMax")
+                                                                          .gte(
+                                                                              (double)
+                                                                                  childAge))))));
+
+                          fs.functions(
+                              fn ->
+                                  fn.fieldValueFactor(
+                                      fvf ->
+                                          fvf.field("avgRating")
+                                              .factor(1.2)
+                                              .modifier(
+                                                  co.elastic.clients.elasticsearch._types.query_dsl
+                                                      .FieldValueFactorModifier.Log1p)
+                                              .missing(0.0)));
+
+                          if (lat != null && lng != null) {
+                            fs.functions(
+                                fn ->
+                                    fn.exp(
+                                        d ->
+                                            d.geo(
+                                                g ->
+                                                    g.field("location")
+                                                        .placement(
+                                                            p ->
+                                                                p.origin(
+                                                                        co.elastic.clients
+                                                                            .elasticsearch._types
+                                                                            .GeoLocation.of(
+                                                                            o ->
+                                                                                o.latlon(
+                                                                                    ll ->
+                                                                                        ll.lat(lat)
+                                                                                            .lon(
+                                                                                                lng))))
+                                                                    .scale("3km")
+                                                                    .offset("0km")
+                                                                    .decay(0.5)))));
+                          }
+
+                          fs.scoreMode(FunctionScoreMode.Sum);
+                          fs.boostMode(FunctionBoostMode.Replace);
+                          return fs;
+                        }))
+            .withPageable(PageRequest.of(0, limit))
+            .build();
+
+    SearchHits<FacilityDocument> hits = operations.search(query, FacilityDocument.class);
+
+    return hits.getSearchHits().stream().map(SearchHit::getContent).toList();
+  }
+
+  @Override
+  public List<String> getDistinctDistrictNames() {
+    NativeQuery query =
+        NativeQuery.builder()
+            .withQuery(q -> q.matchAll(m -> m))
+            .withAggregation(
+                "distinct_districts",
+                co.elastic.clients.elasticsearch._types.aggregations.Aggregation.of(
+                    a -> a.terms(t -> t.field("districtName").size(100))))
+            .withMaxResults(0)
+            .build();
+
+    SearchHits<FacilityDocument> hits = operations.search(query, FacilityDocument.class);
+
+    List<String> districts = new ArrayList<>();
+    if (hits.hasAggregations()) {
+      var aggregations =
+          (org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations)
+              hits.getAggregations();
+      if (aggregations != null) {
+        var termsAgg =
+            aggregations
+                .aggregationsAsMap()
+                .get("distinct_districts")
+                .aggregation()
+                .getAggregate()
+                .sterms();
+        for (var bucket : termsAgg.buckets().array()) {
+          districts.add(bucket.key().stringValue());
+        }
+      }
+    }
+
+    return districts;
   }
 }

--- a/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
@@ -1,0 +1,231 @@
+package com.aidom.api.domain.facility.service;
+
+import com.aidom.api.domain.facility.document.FacilityDocument;
+import com.aidom.api.domain.facility.dto.*;
+import com.aidom.api.domain.facility.entity.Facility;
+import com.aidom.api.domain.facility.entity.FacilityExternalInfo;
+import com.aidom.api.domain.facility.entity.FacilityStats;
+import com.aidom.api.domain.facility.enums.ServiceType;
+import com.aidom.api.domain.facility.repository.FacilityRepository;
+import com.aidom.api.domain.facility.repository.FacilitySearchRepository;
+import com.aidom.api.domain.user.entity.Child;
+import com.aidom.api.domain.user.repository.ChildRepository;
+import com.aidom.api.global.error.CustomException;
+import com.aidom.api.global.error.ErrorCode;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@ConditionalOnProperty(
+    name = "spring.data.elasticsearch.repositories.enabled",
+    havingValue = "true",
+    matchIfMissing = false)
+public class FacilityService {
+
+  private final FacilitySearchRepository facilitySearchRepository;
+  private final FacilityRepository facilityRepository;
+  private final ChildRepository childRepository;
+
+  public Page<FacilityListResponse> listFacilities(
+      String districtName,
+      String serviceType,
+      Boolean isFree,
+      Integer ageMin,
+      Integer ageMax,
+      BigDecimal lat,
+      BigDecimal lng,
+      BigDecimal radius,
+      String careType,
+      Boolean hasRegularProgram,
+      Pageable pageable) {
+
+    Page<FacilityDocument> page =
+        facilitySearchRepository.searchWithFilters(
+            districtName,
+            serviceType,
+            isFree,
+            ageMin,
+            ageMax,
+            lat,
+            lng,
+            radius,
+            careType,
+            hasRegularProgram,
+            pageable);
+
+    return page.map(this::toListResponse);
+  }
+
+  public Page<FacilitySearchResponse> searchFacilities(String keyword, Pageable pageable) {
+    Page<FacilityDocument> page = facilitySearchRepository.searchByFacilityName(keyword, pageable);
+
+    return page.map(this::toSearchResponse);
+  }
+
+  public FacilityDetailResponse getFacility(String facilityId) {
+    Facility facility =
+        facilityRepository
+            .findById(facilityId)
+            .orElseThrow(() -> new CustomException(ErrorCode.FACILITY_NOT_FOUND));
+
+    return toDetailResponse(facility);
+  }
+
+  public List<FacilityRecommendResponse> recommendFacilities(
+      Long childId, BigDecimal lat, BigDecimal lng, int limit) {
+
+    Child child =
+        childRepository
+            .findById(childId)
+            .orElseThrow(() -> new CustomException(ErrorCode.CHILD_NOT_FOUND));
+
+    int childAge = calculateAge(child.getBirthDate());
+
+    Double latVal = lat != null ? lat.doubleValue() : null;
+    Double lngVal = lng != null ? lng.doubleValue() : null;
+
+    List<FacilityDocument> docs =
+        facilitySearchRepository.recommendByChildAge(childAge, latVal, lngVal, limit);
+
+    return docs.stream().map(doc -> toRecommendResponse(doc, childAge)).toList();
+  }
+
+  public List<FacilityListResponse> getNearbyFacilities(
+      BigDecimal lat, BigDecimal lng, BigDecimal radius, int limit) {
+
+    List<FacilityDocument> docs =
+        facilitySearchRepository.searchNearby(
+            lat.doubleValue(), lng.doubleValue(), radius.doubleValue(), limit);
+
+    return docs.stream().map(this::toListResponse).toList();
+  }
+
+  public FacilityFilterResponse getFilters() {
+    List<FacilityFilterResponse.FilterOption> serviceTypes =
+        Arrays.stream(ServiceType.values())
+            .map(
+                st ->
+                    new FacilityFilterResponse.FilterOption(
+                        st.getDescription(), st.getDescription()))
+            .toList();
+
+    List<String> districtNames = facilitySearchRepository.getDistinctDistrictNames();
+    List<FacilityFilterResponse.FilterOption> districts =
+        districtNames.stream()
+            .sorted()
+            .map(name -> new FacilityFilterResponse.FilterOption(name, name))
+            .toList();
+
+    List<FacilityFilterResponse.FilterOption> ageRanges =
+        List.of(
+            new FacilityFilterResponse.FilterOption("0~2세", "0-2"),
+            new FacilityFilterResponse.FilterOption("3~5세", "3-5"),
+            new FacilityFilterResponse.FilterOption("6~9세", "6-9"),
+            new FacilityFilterResponse.FilterOption("10~12세", "10-12"),
+            new FacilityFilterResponse.FilterOption("13세 이상", "13-18"));
+
+    List<FacilityFilterResponse.FilterOption> careTypes =
+        List.of(
+            new FacilityFilterResponse.FilterOption("임시 돌봄", "TEMPORARY"),
+            new FacilityFilterResponse.FilterOption("정규 돌봄", "REGULAR"));
+
+    return new FacilityFilterResponse(serviceTypes, districts, ageRanges, careTypes);
+  }
+
+  private int calculateAge(LocalDate birthDate) {
+    return (int) ChronoUnit.YEARS.between(birthDate, LocalDate.now());
+  }
+
+  private FacilityListResponse toListResponse(FacilityDocument doc) {
+    return new FacilityListResponse(
+        doc.getId(),
+        doc.getFacilityName(),
+        doc.getServiceType(),
+        doc.getDistrictName(),
+        doc.getAddress(),
+        doc.getLocation() != null ? BigDecimal.valueOf(doc.getLocation().getLat()) : null,
+        doc.getLocation() != null ? BigDecimal.valueOf(doc.getLocation().getLon()) : null,
+        BigDecimal.valueOf(doc.getAvgRating()),
+        null,
+        doc.isFree(),
+        doc.isBookingRequired());
+  }
+
+  private FacilitySearchResponse toSearchResponse(FacilityDocument doc) {
+    return new FacilitySearchResponse(
+        doc.getId(),
+        doc.getFacilityName(),
+        doc.getServiceType(),
+        doc.getDistrictName(),
+        doc.getAddress(),
+        BigDecimal.valueOf(doc.getAvgRating()),
+        null);
+  }
+
+  private FacilityDetailResponse toDetailResponse(Facility entity) {
+    FacilityExternalInfo ext = entity.getExternalInfo();
+    FacilityStats stats = entity.getStats();
+
+    return new FacilityDetailResponse(
+        entity.getId(),
+        entity.getFacilityName(),
+        entity.getServiceType().getDescription(),
+        entity.getServiceTypeCode(),
+        entity.getDistrictName(),
+        entity.getDistrictCode(),
+        entity.getAddress(),
+        entity.getLat(),
+        entity.getLng(),
+        entity.getAgeGroup(),
+        entity.getAgeMin(),
+        entity.getAgeMax(),
+        entity.isBookingRequired(),
+        entity.isFree(),
+        entity.getFee(),
+        entity.getMonthlyFee(),
+        entity.getCapacityRegular(),
+        entity.getCapacityTemporary(),
+        entity.getAreaSqm(),
+        entity.getOperatingDays(),
+        entity.getClosedDays(),
+        entity.isHasRegularProgram(),
+        entity.isHasRegularCare(),
+        entity.isHasTemporaryCare(),
+        ext != null ? ext.getPhone() : null,
+        ext != null ? ext.getWebsite() : null,
+        ext != null ? ext.getNaverHours() : null,
+        ext != null ? ext.getBusinessStatus() : null,
+        ext != null ? ext.getThumbnailUrl() : null,
+        stats != null ? stats.getAvgRating() : BigDecimal.ZERO,
+        stats != null ? stats.getAvgRatingSafety() : BigDecimal.ZERO,
+        stats != null ? stats.getAvgRatingCleanliness() : BigDecimal.ZERO,
+        stats != null ? stats.getAvgRatingManagement() : BigDecimal.ZERO,
+        stats != null ? stats.getAvgRatingKindness() : BigDecimal.ZERO,
+        stats != null ? stats.getReviewCount() : 0);
+  }
+
+  private FacilityRecommendResponse toRecommendResponse(FacilityDocument doc, int childAge) {
+    String reason =
+        String.format("%d세 아이에게 적합한 시설이에요 (%d~%d세 대상)", childAge, doc.getAgeMin(), doc.getAgeMax());
+
+    return new FacilityRecommendResponse(
+        doc.getId(),
+        doc.getFacilityName(),
+        doc.getServiceType(),
+        doc.getDistrictName(),
+        BigDecimal.valueOf(doc.getAvgRating()),
+        null,
+        reason);
+  }
+}

--- a/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
@@ -1,7 +1,11 @@
 package com.aidom.api.domain.facility.service;
 
 import com.aidom.api.domain.facility.document.FacilityDocument;
-import com.aidom.api.domain.facility.dto.*;
+import com.aidom.api.domain.facility.dto.FacilityDetailResponse;
+import com.aidom.api.domain.facility.dto.FacilityFilterResponse;
+import com.aidom.api.domain.facility.dto.FacilityListResponse;
+import com.aidom.api.domain.facility.dto.FacilityRecommendResponse;
+import com.aidom.api.domain.facility.dto.FacilitySearchResponse;
 import com.aidom.api.domain.facility.entity.Facility;
 import com.aidom.api.domain.facility.entity.FacilityExternalInfo;
 import com.aidom.api.domain.facility.entity.FacilityStats;
@@ -9,7 +13,7 @@ import com.aidom.api.domain.facility.enums.ServiceType;
 import com.aidom.api.domain.facility.repository.FacilityRepository;
 import com.aidom.api.domain.facility.repository.FacilitySearchRepository;
 import com.aidom.api.domain.user.entity.Child;
-import com.aidom.api.domain.user.repository.ChildRepository;
+import com.aidom.api.domain.user.service.ChildService;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
 import java.math.BigDecimal;
@@ -35,7 +39,7 @@ public class FacilityService {
 
   private final FacilitySearchRepository facilitySearchRepository;
   private final FacilityRepository facilityRepository;
-  private final ChildRepository childRepository;
+  private final ChildService childService;
 
   public Page<FacilityListResponse> listFacilities(
       String districtName,
@@ -85,10 +89,7 @@ public class FacilityService {
   public List<FacilityRecommendResponse> recommendFacilities(
       Long childId, BigDecimal lat, BigDecimal lng, int limit) {
 
-    Child child =
-        childRepository
-            .findById(childId)
-            .orElseThrow(() -> new CustomException(ErrorCode.CHILD_NOT_FOUND));
+    Child child = childService.getChildById(childId);
 
     int childAge = calculateAge(child.getBirthDate());
 
@@ -133,7 +134,7 @@ public class FacilityService {
             new FacilityFilterResponse.FilterOption("3~5세", "3-5"),
             new FacilityFilterResponse.FilterOption("6~9세", "6-9"),
             new FacilityFilterResponse.FilterOption("10~12세", "10-12"),
-            new FacilityFilterResponse.FilterOption("13세 이상", "13-18"));
+            new FacilityFilterResponse.FilterOption("13~18세", "13-18"));
 
     List<FacilityFilterResponse.FilterOption> careTypes =
         List.of(

--- a/src/main/java/com/aidom/api/domain/user/repository/ChildRepository.java
+++ b/src/main/java/com/aidom/api/domain/user/repository/ChildRepository.java
@@ -1,0 +1,6 @@
+package com.aidom.api.domain.user.repository;
+
+import com.aidom.api.domain.user.entity.Child;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChildRepository extends JpaRepository<Child, Long> {}

--- a/src/main/java/com/aidom/api/domain/user/service/ChildService.java
+++ b/src/main/java/com/aidom/api/domain/user/service/ChildService.java
@@ -1,0 +1,23 @@
+package com.aidom.api.domain.user.service;
+
+import com.aidom.api.domain.user.entity.Child;
+import com.aidom.api.domain.user.repository.ChildRepository;
+import com.aidom.api.global.error.CustomException;
+import com.aidom.api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChildService {
+
+  private final ChildRepository childRepository;
+
+  public Child getChildById(Long childId) {
+    return childRepository
+        .findById(childId)
+        .orElseThrow(() -> new CustomException(ErrorCode.CHILD_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/aidom/api/global/error/ErrorCode.java
+++ b/src/main/java/com/aidom/api/global/error/ErrorCode.java
@@ -33,6 +33,9 @@ public enum ErrorCode {
   // Facility
   FACILITY_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "시설을 찾을 수 없습니다."),
 
+  // Child
+  CHILD_NOT_FOUND(HttpStatus.NOT_FOUND, "CH001", "아이 정보를 찾을 수 없습니다."),
+
   // Bookmark
   ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "B001", "이미 찜한 시설입니다."),
   BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "B002", "찜 내역을 찾을 수 없습니다."),

--- a/src/main/java/com/aidom/api/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/aidom/api/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.aidom.api.global.error;
 
+import jakarta.validation.ConstraintViolationException;
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
@@ -36,20 +38,46 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
             .map(error -> new ValidationError(error.getField(), error.getDefaultMessage()))
             .toList();
 
-    // ProblemDetail 기본 설정
-    ProblemDetail problemDetail =
-        ProblemDetail.forStatusAndDetail(status, "요청 데이터에 유효하지 않은 값이 포함되어 있습니다.");
+    return handleValidationException(ex, headers, status, request, errors);
+  }
 
-    // 표준 필드 커스텀 (type, title)
-    problemDetail.setType(URI.create("https://aidom.kr/errors/validation-failed"));
-    problemDetail.setTitle("입력값이 올바르지 않습니다");
+  @Override
+  protected ResponseEntity<Object> handleHandlerMethodValidationException(
+      HandlerMethodValidationException ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request) {
 
-    // 비표준 커스텀 필드 추가 (errorCode, timestamp, errors 배열)
-    problemDetail.setProperty("errorCode", ErrorCode.INVALID_INPUT_VALUE.getCode());
-    problemDetail.setProperty("timestamp", Instant.now()); // ISO-8601 포맷(Z)
-    problemDetail.setProperty("errors", errors);
+    List<ValidationError> errors =
+        ex.getParameterValidationResults().stream()
+            .flatMap(
+                result ->
+                    result.getResolvableErrors().stream()
+                        .map(
+                            error ->
+                                new ValidationError(
+                                    result.getMethodParameter().getParameterName(),
+                                    error.getDefaultMessage())))
+            .toList();
 
-    return handleExceptionInternal(ex, problemDetail, headers, status, request);
+    return handleValidationException(ex, headers, status, request, errors);
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<Object> handleConstraintViolationException(
+      ConstraintViolationException ex, WebRequest request) {
+
+    List<ValidationError> errors =
+        ex.getConstraintViolations().stream()
+            .map(
+                violation ->
+                    new ValidationError(
+                        extractFieldName(violation.getPropertyPath().toString()),
+                        violation.getMessage()))
+            .toList();
+
+    return handleValidationException(
+        ex, new HttpHeaders(), HttpStatus.BAD_REQUEST, request, errors);
   }
 
   @ExceptionHandler(CustomException.class)
@@ -79,5 +107,28 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     problemDetail.setProperty("errorCode", ErrorCode.INTERNAL_SERVER_ERROR.getCode());
 
     return problemDetail;
+  }
+
+  private ResponseEntity<Object> handleValidationException(
+      Exception ex,
+      HttpHeaders headers,
+      HttpStatusCode status,
+      WebRequest request,
+      List<ValidationError> errors) {
+
+    ProblemDetail problemDetail =
+        ProblemDetail.forStatusAndDetail(status, "요청 데이터에 유효하지 않은 값이 포함되어 있습니다.");
+    problemDetail.setType(URI.create("https://aidom.kr/errors/validation-failed"));
+    problemDetail.setTitle("입력값이 올바르지 않습니다");
+    problemDetail.setProperty("errorCode", ErrorCode.INVALID_INPUT_VALUE.getCode());
+    problemDetail.setProperty("timestamp", Instant.now());
+    problemDetail.setProperty("errors", errors);
+
+    return handleExceptionInternal(ex, problemDetail, headers, status, request);
+  }
+
+  private String extractFieldName(String propertyPath) {
+    int index = propertyPath.lastIndexOf('.');
+    return index >= 0 ? propertyPath.substring(index + 1) : propertyPath;
   }
 }

--- a/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
@@ -1,0 +1,230 @@
+package com.aidom.api.domain.facility.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aidom.api.domain.facility.dto.*;
+import com.aidom.api.domain.facility.service.FacilityService;
+import com.aidom.api.global.error.CustomException;
+import com.aidom.api.global.error.ErrorCode;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(FacilityController.class)
+@ActiveProfiles("test")
+@TestPropertySource(properties = "spring.data.elasticsearch.repositories.enabled=true")
+class FacilityControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private FacilityService facilityService;
+
+  @Test
+  @DisplayName("GET /api/v1/facilities - 시설 목록 조회")
+  void getFacilities() throws Exception {
+    FacilityListResponse response =
+        new FacilityListResponse(
+            "FAC001",
+            "강남 키움센터",
+            "우리동네키움센터",
+            "강남구",
+            "서울특별시 강남구 테헤란로 123",
+            new BigDecimal("37.5665"),
+            new BigDecimal("126.978"),
+            new BigDecimal("4.5"),
+            null,
+            true,
+            false);
+
+    given(
+            facilityService.listFacilities(
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                any(Pageable.class)))
+        .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+    mockMvc
+        .perform(get("/api/v1/facilities"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].id").value("FAC001"))
+        .andExpect(jsonPath("$.content[0].facilityName").value("강남 키움센터"))
+        .andExpect(jsonPath("$.totalElements").value(1));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/facilities/search - 시설 검색")
+  void searchFacilities() throws Exception {
+    FacilitySearchResponse response =
+        new FacilitySearchResponse(
+            "FAC001",
+            "강남 키움센터",
+            "우리동네키움센터",
+            "강남구",
+            "서울특별시 강남구 테헤란로 123",
+            new BigDecimal("4.5"),
+            null);
+
+    given(facilityService.searchFacilities(eq("키움"), any(Pageable.class)))
+        .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
+
+    mockMvc
+        .perform(get("/api/v1/facilities/search").param("keyword", "키움"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].id").value("FAC001"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/facilities/{facilityId} - 시설 상세 조회")
+  void getFacility() throws Exception {
+    FacilityDetailResponse response =
+        new FacilityDetailResponse(
+            "FAC001",
+            "강남 키움센터",
+            "우리동네키움센터",
+            "KIUM_CENTER",
+            "강남구",
+            "11680",
+            "서울특별시 강남구 테헤란로 123",
+            new BigDecimal("37.5665"),
+            new BigDecimal("126.978"),
+            "3~12세",
+            3,
+            12,
+            false,
+            true,
+            null,
+            null,
+            30,
+            10,
+            new BigDecimal("120.50"),
+            "월~금",
+            "주말",
+            false,
+            true,
+            false,
+            "02-1234-5678",
+            null,
+            null,
+            null,
+            null,
+            new BigDecimal("4.5"),
+            new BigDecimal("4.3"),
+            new BigDecimal("4.4"),
+            new BigDecimal("4.2"),
+            new BigDecimal("4.6"),
+            42);
+
+    given(facilityService.getFacility("FAC001")).willReturn(response);
+
+    mockMvc
+        .perform(get("/api/v1/facilities/FAC001"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value("FAC001"))
+        .andExpect(jsonPath("$.facilityName").value("강남 키움센터"))
+        .andExpect(jsonPath("$.reviewCount").value(42));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/facilities/{facilityId} - 존재하지 않는 시설 404")
+  void getFacility_notFound() throws Exception {
+    given(facilityService.getFacility("INVALID"))
+        .willThrow(new CustomException(ErrorCode.FACILITY_NOT_FOUND));
+
+    mockMvc.perform(get("/api/v1/facilities/INVALID")).andExpect(status().isNotFound());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/facilities/recommend - AI 추천")
+  void recommendFacilities() throws Exception {
+    FacilityRecommendResponse response =
+        new FacilityRecommendResponse(
+            "FAC001",
+            "강남 키움센터",
+            "우리동네키움센터",
+            "강남구",
+            new BigDecimal("4.5"),
+            null,
+            "7세 아이에게 적합한 시설이에요 (3~12세 대상)");
+
+    given(facilityService.recommendFacilities(eq(1L), isNull(), isNull(), eq(5)))
+        .willReturn(List.of(response));
+
+    mockMvc
+        .perform(get("/api/v1/facilities/recommend").param("childId", "1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value("FAC001"))
+        .andExpect(jsonPath("$[0].recommendReason").exists());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/facilities/nearby - 주변 시설 조회")
+  void getNearbyFacilities() throws Exception {
+    FacilityListResponse response =
+        new FacilityListResponse(
+            "FAC001",
+            "강남 키움센터",
+            "우리동네키움센터",
+            "강남구",
+            "서울특별시 강남구 테헤란로 123",
+            new BigDecimal("37.5665"),
+            new BigDecimal("126.978"),
+            new BigDecimal("4.5"),
+            null,
+            true,
+            false);
+
+    given(
+            facilityService.getNearbyFacilities(
+                eq(new BigDecimal("37.5172")),
+                eq(new BigDecimal("127.0473")),
+                eq(new BigDecimal("3.0")),
+                eq(10)))
+        .willReturn(List.of(response));
+
+    mockMvc
+        .perform(get("/api/v1/facilities/nearby").param("lat", "37.5172").param("lng", "127.0473"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value("FAC001"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/facilities/filters - 필터 옵션 조회")
+  void getFilters() throws Exception {
+    FacilityFilterResponse response =
+        new FacilityFilterResponse(
+            List.of(new FacilityFilterResponse.FilterOption("우리동네키움센터", "우리동네키움센터")),
+            List.of(new FacilityFilterResponse.FilterOption("강남구", "강남구")),
+            List.of(new FacilityFilterResponse.FilterOption("6~9세", "6-9")),
+            List.of(new FacilityFilterResponse.FilterOption("임시 돌봄", "TEMPORARY")));
+
+    given(facilityService.getFilters()).willReturn(response);
+
+    mockMvc
+        .perform(get("/api/v1/facilities/filters"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.serviceTypes[0].label").value("우리동네키움센터"))
+        .andExpect(jsonPath("$.districts[0].label").value("강남구"));
+  }
+}

--- a/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
@@ -1,12 +1,18 @@
 package com.aidom.api.domain.facility.controller;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.aidom.api.domain.facility.dto.*;
+import com.aidom.api.domain.facility.dto.FacilityDetailResponse;
+import com.aidom.api.domain.facility.dto.FacilityFilterResponse;
+import com.aidom.api.domain.facility.dto.FacilityListResponse;
+import com.aidom.api.domain.facility.dto.FacilityRecommendResponse;
+import com.aidom.api.domain.facility.dto.FacilitySearchResponse;
 import com.aidom.api.domain.facility.service.FacilityService;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;

--- a/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
@@ -80,6 +80,16 @@ class FacilityControllerTest {
   }
 
   @Test
+  @DisplayName("GET /api/v1/facilities - 음수 페이지 번호는 400")
+  void getFacilities_invalidPage() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/facilities").param("page", "-1"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_INPUT_VALUE.getCode()))
+        .andExpect(jsonPath("$.errors[0].field").value("page"));
+  }
+
+  @Test
   @DisplayName("GET /api/v1/facilities/search - 시설 검색")
   void searchFacilities() throws Exception {
     FacilitySearchResponse response =
@@ -99,6 +109,16 @@ class FacilityControllerTest {
         .perform(get("/api/v1/facilities/search").param("keyword", "키움"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.content[0].id").value("FAC001"));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/facilities/search - 0 이하 페이지 크기는 400")
+  void searchFacilities_invalidSize() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/facilities/search").param("keyword", "키움").param("size", "0"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_INPUT_VALUE.getCode()))
+        .andExpect(jsonPath("$.errors[0].field").value("size"));
   }
 
   @Test
@@ -182,6 +202,16 @@ class FacilityControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].id").value("FAC001"))
         .andExpect(jsonPath("$[0].recommendReason").exists());
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/facilities/recommend - 0 이하 limit은 400")
+  void recommendFacilities_invalidLimit() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/facilities/recommend").param("childId", "1").param("limit", "0"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_INPUT_VALUE.getCode()))
+        .andExpect(jsonPath("$.errors[0].field").value("limit"));
   }
 
   @Test

--- a/src/test/java/com/aidom/api/domain/facility/repository/FacilitySearchRepositoryIntegrationTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/repository/FacilitySearchRepositoryIntegrationTest.java
@@ -77,6 +77,7 @@ class FacilitySearchRepositoryIntegrationTest {
                 .bookingRequired(false)
                 .hasRegularCare(true)
                 .hasTemporaryCare(false)
+                .hasRegularProgram(true)
                 .avgRating(4.5f)
                 .build(),
             FacilityDocument.builder()
@@ -92,6 +93,7 @@ class FacilitySearchRepositoryIntegrationTest {
                 .bookingRequired(true)
                 .hasRegularCare(true)
                 .hasTemporaryCare(true)
+                .hasRegularProgram(true)
                 .avgRating(4.2f)
                 .build(),
             FacilityDocument.builder()
@@ -107,6 +109,7 @@ class FacilitySearchRepositoryIntegrationTest {
                 .bookingRequired(false)
                 .hasRegularCare(false)
                 .hasTemporaryCare(true)
+                .hasRegularProgram(false)
                 .avgRating(3.8f)
                 .build());
 
@@ -207,5 +210,206 @@ class FacilitySearchRepositoryIntegrationTest {
     assertThat(results.getContent())
         .extracting(FacilityDocument::getId)
         .containsExactlyInAnyOrder("FAC002", "FAC003");
+  }
+
+  @Test
+  @DisplayName("searchWithFilters - districtName 필터로 해당 구의 시설만 반환된다")
+  void searchWithFilters_districtName() {
+    Page<FacilityDocument> results =
+        facilitySearchRepository.searchWithFilters(
+            "강남구", null, null, null, null, null, null, null, null, null, PageRequest.of(0, 10));
+
+    assertThat(results.getContent()).hasSize(2);
+    assertThat(results.getContent())
+        .extracting(FacilityDocument::getId)
+        .containsExactlyInAnyOrder("FAC001", "FAC003");
+  }
+
+  @Test
+  @DisplayName("searchWithFilters - serviceType 필터로 해당 유형만 반환된다")
+  void searchWithFilters_serviceType() {
+    Page<FacilityDocument> results =
+        facilitySearchRepository.searchWithFilters(
+            null, "지역아동센터", null, null, null, null, null, null, null, null, PageRequest.of(0, 10));
+
+    assertThat(results.getContent()).hasSize(2);
+    assertThat(results.getContent())
+        .extracting(FacilityDocument::getId)
+        .containsExactlyInAnyOrder("FAC002", "FAC003");
+  }
+
+  @Test
+  @DisplayName("searchWithFilters - isFree 필터로 무료 시설만 반환된다")
+  void searchWithFilters_isFree() {
+    Page<FacilityDocument> results =
+        facilitySearchRepository.searchWithFilters(
+            null, null, true, null, null, null, null, null, null, null, PageRequest.of(0, 10));
+
+    assertThat(results.getContent()).hasSize(2);
+    assertThat(results.getContent())
+        .extracting(FacilityDocument::getId)
+        .containsExactlyInAnyOrder("FAC001", "FAC003");
+  }
+
+  @Test
+  @DisplayName("searchWithFilters - 여러 필터 조합으로 조회한다")
+  void searchWithFilters_combined() {
+    Page<FacilityDocument> results =
+        facilitySearchRepository.searchWithFilters(
+            "강남구", null, true, null, null, null, null, null, null, null, PageRequest.of(0, 10));
+
+    assertThat(results.getContent()).hasSize(2);
+    assertThat(results.getContent())
+        .extracting(FacilityDocument::getId)
+        .containsExactlyInAnyOrder("FAC001", "FAC003");
+  }
+
+  @Test
+  @DisplayName("searchWithFilters - 연령 범위 필터로 해당 연령을 포함하는 시설만 반환된다")
+  void searchWithFilters_ageRange() {
+    // ageMin=4 이면 시설의 ageMax >= 4인 것만, ageMax=10 이면 시설의 ageMin <= 10인 것만
+    Page<FacilityDocument> results =
+        facilitySearchRepository.searchWithFilters(
+            null, null, null, 4, 5, null, null, null, null, null, PageRequest.of(0, 10));
+
+    // FAC001: 3~12 (포함), FAC002: 5~15 (포함), FAC003: 6~13 (ageMin=6 > ageMax=5 → 제외)
+    assertThat(results.getContent()).hasSize(2);
+    assertThat(results.getContent())
+        .extracting(FacilityDocument::getId)
+        .containsExactlyInAnyOrder("FAC001", "FAC002");
+  }
+
+  @Test
+  @DisplayName("searchNearby - 위치 기반으로 가까운 시설을 반환한다")
+  void searchNearby_returnsNearbyFacilities() {
+    // 강남역 근처 좌표, 반경 20km (모든 시설 포함할 수 있는 범위)
+    List<FacilityDocument> results =
+        facilitySearchRepository.searchNearby(37.5665, 126.978, 20.0, 10);
+
+    assertThat(results).isNotEmpty();
+    assertThat(results).hasSizeLessThanOrEqualTo(10);
+  }
+
+  @Test
+  @DisplayName("searchNearby - 좁은 반경에서는 가까운 시설만 반환된다")
+  void searchNearby_narrowRadius() {
+    // FAC001 좌표와 매우 가까운 곳에서 검색, 매우 작은 반경
+    List<FacilityDocument> results =
+        facilitySearchRepository.searchNearby(37.5665, 126.978, 0.1, 10);
+
+    // 0.1km 반경이므로 FAC001만 포함될 가능성이 높음
+    assertThat(results).hasSizeLessThanOrEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("recommendByChildAge - 해당 나이를 포함하는 시설을 추천한다")
+  void recommendByChildAge_returnsMatchingFacilities() {
+    // 7세 아이 → FAC001(3~12), FAC002(5~15), FAC003(6~13) 모두 매칭
+    List<FacilityDocument> results =
+        facilitySearchRepository.recommendByChildAge(7, null, null, 10);
+
+    assertThat(results).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("recommendByChildAge - 범위 밖 나이면 빈 결과를 반환한다")
+  void recommendByChildAge_noMatch() {
+    // 20세 → 모든 시설의 ageMax보다 큼
+    List<FacilityDocument> results =
+        facilitySearchRepository.recommendByChildAge(20, null, null, 10);
+
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  @DisplayName("recommendByChildAge - 위치 기반 decay가 적용된다")
+  void recommendByChildAge_withLocation() {
+    List<FacilityDocument> results =
+        facilitySearchRepository.recommendByChildAge(7, 37.5665, 126.978, 10);
+
+    assertThat(results).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("searchWithFilters - careType=TEMPORARY 필터로 임시돌봄 가능 시설만 반환된다")
+  void searchWithFilters_careTypeTemporary() {
+    // FAC002: hasTemporaryCare=true, FAC003: hasTemporaryCare=true
+    Page<FacilityDocument> results =
+        facilitySearchRepository.searchWithFilters(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "TEMPORARY",
+            null,
+            PageRequest.of(0, 10));
+
+    assertThat(results.getContent()).hasSize(2);
+    assertThat(results.getContent())
+        .extracting(FacilityDocument::getId)
+        .containsExactlyInAnyOrder("FAC002", "FAC003");
+  }
+
+  @Test
+  @DisplayName("searchWithFilters - careType=REGULAR 필터로 정규돌봄 가능 시설만 반환된다")
+  void searchWithFilters_careTypeRegular() {
+    // FAC001: hasRegularCare=true, FAC002: hasRegularCare=true
+    Page<FacilityDocument> results =
+        facilitySearchRepository.searchWithFilters(
+            null, null, null, null, null, null, null, null, "REGULAR", null, PageRequest.of(0, 10));
+
+    assertThat(results.getContent()).hasSize(2);
+    assertThat(results.getContent())
+        .extracting(FacilityDocument::getId)
+        .containsExactlyInAnyOrder("FAC001", "FAC002");
+  }
+
+  @Test
+  @DisplayName("searchWithFilters - hasRegularProgram=true 필터로 정규프로그램 시설만 반환된다")
+  void searchWithFilters_hasRegularProgramTrue() {
+    // FAC001: hasRegularProgram=true, FAC002: hasRegularProgram=true
+    Page<FacilityDocument> results =
+        facilitySearchRepository.searchWithFilters(
+            null, null, null, null, null, null, null, null, null, true, PageRequest.of(0, 10));
+
+    assertThat(results.getContent()).hasSize(2);
+    assertThat(results.getContent())
+        .extracting(FacilityDocument::getId)
+        .containsExactlyInAnyOrder("FAC001", "FAC002");
+  }
+
+  @Test
+  @DisplayName("searchWithFilters - hasRegularProgram=false 필터로 정규프로그램 없는 시설만 반환된다")
+  void searchWithFilters_hasRegularProgramFalse() {
+    // FAC003: hasRegularProgram=false
+    Page<FacilityDocument> results =
+        facilitySearchRepository.searchWithFilters(
+            null, null, null, null, null, null, null, null, null, false, PageRequest.of(0, 10));
+
+    assertThat(results.getContent()).hasSize(1);
+    assertThat(results.getContent().get(0).getId()).isEqualTo("FAC003");
+  }
+
+  @Test
+  @DisplayName("recommendByChildAge - 평점이 높은 시설이 먼저 추천된다")
+  void recommendByChildAge_orderedByRating() {
+    // 7세: 3개 모두 매칭, avgRating: FAC001=4.5 > FAC002=4.2 > FAC003=3.8
+    List<FacilityDocument> results =
+        facilitySearchRepository.recommendByChildAge(7, null, null, 10);
+
+    assertThat(results).hasSize(3);
+    assertThat(results.get(0).getId()).isEqualTo("FAC001");
+  }
+
+  @Test
+  @DisplayName("getDistinctDistrictNames - 고유한 자치구명 목록을 반환한다")
+  void getDistinctDistrictNames() {
+    List<String> districts = facilitySearchRepository.getDistinctDistrictNames();
+
+    assertThat(districts).containsExactlyInAnyOrder("강남구", "서초구");
   }
 }

--- a/src/test/java/com/aidom/api/domain/facility/repository/FacilitySearchRepositoryIntegrationTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/repository/FacilitySearchRepositoryIntegrationTest.java
@@ -293,12 +293,13 @@ class FacilitySearchRepositoryIntegrationTest {
   @Test
   @DisplayName("searchNearby - 좁은 반경에서는 가까운 시설만 반환된다")
   void searchNearby_narrowRadius() {
-    // FAC001 좌표와 매우 가까운 곳에서 검색, 매우 작은 반경
+    // FAC001 좌표와 동일한 지점에서 검색, 0.1km 반경
     List<FacilityDocument> results =
         facilitySearchRepository.searchNearby(37.5665, 126.978, 0.1, 10);
 
-    // 0.1km 반경이므로 FAC001만 포함될 가능성이 높음
-    assertThat(results).hasSizeLessThanOrEqualTo(1);
+    // 0.1km 반경이므로 FAC001(동일 좌표)만 정확히 1건 반환
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getId()).isEqualTo("FAC001");
   }
 
   @Test

--- a/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
@@ -1,0 +1,214 @@
+package com.aidom.api.domain.facility.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+import com.aidom.api.domain.facility.document.FacilityDocument;
+import com.aidom.api.domain.facility.dto.*;
+import com.aidom.api.domain.facility.entity.Facility;
+import com.aidom.api.domain.facility.enums.ServiceType;
+import com.aidom.api.domain.facility.repository.FacilityRepository;
+import com.aidom.api.domain.facility.repository.FacilitySearchRepository;
+import com.aidom.api.domain.user.entity.Child;
+import com.aidom.api.domain.user.repository.ChildRepository;
+import com.aidom.api.global.common.entity.Gender;
+import com.aidom.api.global.error.CustomException;
+import com.aidom.api.global.error.ErrorCode;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+
+@ExtendWith(MockitoExtension.class)
+class FacilityServiceTest {
+
+  @Mock private FacilitySearchRepository facilitySearchRepository;
+  @Mock private FacilityRepository facilityRepository;
+  @Mock private ChildRepository childRepository;
+
+  @InjectMocks private FacilityService facilityService;
+
+  @Test
+  @DisplayName("키워드 검색 시 ES 결과를 FacilitySearchResponse로 매핑한다")
+  void searchFacilities_mapsResult() {
+    FacilityDocument doc = createDocument("FAC001", "강남 키움센터");
+    Page<FacilityDocument> page = new PageImpl<>(List.of(doc), PageRequest.of(0, 10), 1);
+    given(facilitySearchRepository.searchByFacilityName(eq("키움"), any(Pageable.class)))
+        .willReturn(page);
+
+    Page<FacilitySearchResponse> result =
+        facilityService.searchFacilities("키움", PageRequest.of(0, 10));
+
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).id()).isEqualTo("FAC001");
+    assertThat(result.getContent().get(0).facilityName()).isEqualTo("강남 키움센터");
+  }
+
+  @Test
+  @DisplayName("필터 조건으로 시설 목록을 조회한다")
+  void listFacilities_withFilters() {
+    FacilityDocument doc = createDocument("FAC001", "강남 키움센터");
+    Page<FacilityDocument> page = new PageImpl<>(List.of(doc), PageRequest.of(0, 10), 1);
+    given(
+            facilitySearchRepository.searchWithFilters(
+                eq("강남구"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                any(Pageable.class)))
+        .willReturn(page);
+
+    Page<FacilityListResponse> result =
+        facilityService.listFacilities(
+            "강남구", null, null, null, null, null, null, null, null, null, PageRequest.of(0, 10));
+
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).districtName()).isEqualTo("강남구");
+  }
+
+  @Test
+  @DisplayName("시설 상세 조회 성공")
+  void getFacility_success() {
+    Facility facility = createFacility("FAC001");
+    given(facilityRepository.findById("FAC001")).willReturn(Optional.of(facility));
+
+    FacilityDetailResponse result = facilityService.getFacility("FAC001");
+
+    assertThat(result.id()).isEqualTo("FAC001");
+    assertThat(result.facilityName()).isEqualTo("테스트 센터");
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 시설 상세 조회 시 FACILITY_NOT_FOUND 예외 발생")
+  void getFacility_notFound() {
+    given(facilityRepository.findById("INVALID")).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> facilityService.getFacility("INVALID"))
+        .isInstanceOf(CustomException.class)
+        .extracting(e -> ((CustomException) e).getErrorCode())
+        .isEqualTo(ErrorCode.FACILITY_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("아이 나이 기반으로 시설을 추천한다")
+  void recommendFacilities_mapsResult() {
+    Child child =
+        Child.builder()
+            .name("테스트")
+            .birthDate(LocalDate.now().minusYears(7))
+            .gender(Gender.MALE)
+            .build();
+    given(childRepository.findById(1L)).willReturn(Optional.of(child));
+
+    FacilityDocument doc = createDocument("FAC001", "강남 키움센터");
+    given(facilitySearchRepository.recommendByChildAge(eq(7), isNull(), isNull(), eq(5)))
+        .willReturn(List.of(doc));
+
+    List<FacilityRecommendResponse> result = facilityService.recommendFacilities(1L, null, null, 5);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).id()).isEqualTo("FAC001");
+    assertThat(result.get(0).recommendReason()).contains("7세");
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 아이 ID로 추천 요청 시 CHILD_NOT_FOUND 예외 발생")
+  void recommendFacilities_childNotFound() {
+    given(childRepository.findById(999L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> facilityService.recommendFacilities(999L, null, null, 5))
+        .isInstanceOf(CustomException.class)
+        .extracting(e -> ((CustomException) e).getErrorCode())
+        .isEqualTo(ErrorCode.CHILD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("주변 시설을 조회한다")
+  void getNearbyFacilities_returnsResults() {
+    FacilityDocument doc = createDocument("FAC001", "강남 키움센터");
+    given(facilitySearchRepository.searchNearby(eq(37.5), eq(127.0), eq(3.0), eq(10)))
+        .willReturn(List.of(doc));
+
+    List<FacilityListResponse> result =
+        facilityService.getNearbyFacilities(
+            new BigDecimal("37.5"), new BigDecimal("127.0"), new BigDecimal("3.0"), 10);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).id()).isEqualTo("FAC001");
+  }
+
+  @Test
+  @DisplayName("필터 옵션을 반환한다")
+  void getFilters_returnsFilterOptions() {
+    given(facilitySearchRepository.getDistinctDistrictNames()).willReturn(List.of("강남구", "서초구"));
+
+    FacilityFilterResponse result = facilityService.getFilters();
+
+    assertThat(result.serviceTypes()).hasSize(ServiceType.values().length);
+    assertThat(result.serviceTypes())
+        .extracting(FacilityFilterResponse.FilterOption::value)
+        .contains("우리동네키움센터", "지역아동센터");
+    assertThat(result.districts()).hasSize(2);
+    assertThat(result.ageRanges()).isNotEmpty();
+    assertThat(result.careTypes()).isNotEmpty();
+  }
+
+  private FacilityDocument createDocument(String id, String name) {
+    return FacilityDocument.builder()
+        .id(id)
+        .facilityName(name)
+        .serviceType("우리동네키움센터")
+        .districtName("강남구")
+        .address("서울특별시 강남구 테헤란로 123")
+        .location(new GeoPoint(37.5665, 126.978))
+        .ageMin(3)
+        .ageMax(12)
+        .isFree(true)
+        .bookingRequired(false)
+        .hasRegularCare(true)
+        .hasTemporaryCare(false)
+        .avgRating(4.5f)
+        .build();
+  }
+
+  private Facility createFacility(String id) {
+    return Facility.builder()
+        .id(id)
+        .facilityName("테스트 센터")
+        .serviceTypeCode("A")
+        .serviceType(ServiceType.CHILD_CENTER)
+        .districtCode("11680")
+        .districtName("강남구")
+        .address("서울특별시 강남구 테헤란로 123")
+        .lat(new BigDecimal("37.5665"))
+        .lng(new BigDecimal("126.978"))
+        .ageGroup("3~12세")
+        .ageMin(3)
+        .ageMax(12)
+        .bookingRequired(false)
+        .isFree(true)
+        .hasRegularProgram(false)
+        .hasRegularCare(true)
+        .hasTemporaryCare(false)
+        .build();
+  }
+}

--- a/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
@@ -2,17 +2,23 @@ package com.aidom.api.domain.facility.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 
 import com.aidom.api.domain.facility.document.FacilityDocument;
-import com.aidom.api.domain.facility.dto.*;
+import com.aidom.api.domain.facility.dto.FacilityDetailResponse;
+import com.aidom.api.domain.facility.dto.FacilityFilterResponse;
+import com.aidom.api.domain.facility.dto.FacilityListResponse;
+import com.aidom.api.domain.facility.dto.FacilityRecommendResponse;
+import com.aidom.api.domain.facility.dto.FacilitySearchResponse;
 import com.aidom.api.domain.facility.entity.Facility;
 import com.aidom.api.domain.facility.enums.ServiceType;
 import com.aidom.api.domain.facility.repository.FacilityRepository;
 import com.aidom.api.domain.facility.repository.FacilitySearchRepository;
 import com.aidom.api.domain.user.entity.Child;
-import com.aidom.api.domain.user.repository.ChildRepository;
+import com.aidom.api.domain.user.service.ChildService;
 import com.aidom.api.global.common.entity.Gender;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
@@ -37,7 +43,7 @@ class FacilityServiceTest {
 
   @Mock private FacilitySearchRepository facilitySearchRepository;
   @Mock private FacilityRepository facilityRepository;
-  @Mock private ChildRepository childRepository;
+  @Mock private ChildService childService;
 
   @InjectMocks private FacilityService facilityService;
 
@@ -117,7 +123,7 @@ class FacilityServiceTest {
             .birthDate(LocalDate.now().minusYears(7))
             .gender(Gender.MALE)
             .build();
-    given(childRepository.findById(1L)).willReturn(Optional.of(child));
+    given(childService.getChildById(1L)).willReturn(child);
 
     FacilityDocument doc = createDocument("FAC001", "강남 키움센터");
     given(facilitySearchRepository.recommendByChildAge(eq(7), isNull(), isNull(), eq(5)))
@@ -133,7 +139,8 @@ class FacilityServiceTest {
   @Test
   @DisplayName("존재하지 않는 아이 ID로 추천 요청 시 CHILD_NOT_FOUND 예외 발생")
   void recommendFacilities_childNotFound() {
-    given(childRepository.findById(999L)).willReturn(Optional.empty());
+    given(childService.getChildById(999L))
+        .willThrow(new CustomException(ErrorCode.CHILD_NOT_FOUND));
 
     assertThatThrownBy(() -> facilityService.recommendFacilities(999L, null, null, 5))
         .isInstanceOf(CustomException.class)


### PR DESCRIPTION
## Summary
- FacilityService 구현: 목록 조회, 키워드 검색, 상세 조회, AI 추천, 주변 시설, 필터 옵션 6개 엔드포인트
- ES 커스텀 쿼리: searchWithFilters(필터 검색), searchNearby(geo_distance), recommendByChildAge(function_score)
- FacilityController 서비스 연동 (기존 빈 Controller → 실 구현)
- FacilityDocument에 hasRegularProgram 필드 추가
- ChildService를 통한 도메인 간 의존성 분리 (FacilityService → ChildService)
- service_type_code 컬럼 길이 변경 (20 → 30) + DDL 마이그레이션 스크립트
- BigDecimal.toPlainString()으로 ES distance 문자열 안전 구성

## Test plan
- [x] FacilityServiceTest: 6개 서비스 메서드 단위 테스트
- [x] FacilityControllerTest: 6개 엔드포인트 HTTP 요청/응답 검증
- [x] FacilitySearchRepositoryIntegrationTest: 필터 검색, 주변 검색, 추천 쿼리, hasRegularProgram 필터 ES 통합 테스트
- [ ] 운영 배포 시 `sql/V2__alter_service_type_code_length.sql` DDL 실행 필요
- [ ] 기존 ES 인덱스가 있는 환경에서는 hasRegularProgram 매핑을 위해 재색인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)