### PR TITLE
feat: Admin API Basic Auth 인증 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
@@ -37,6 +38,7 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:elasticsearch'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/src/main/java/com/aidom/api/domain/facility/controller/FacilityAdminController.java
+++ b/src/main/java/com/aidom/api/domain/facility/controller/FacilityAdminController.java
@@ -1,10 +1,10 @@
 package com.aidom.api.domain.facility.controller;
 
+import com.aidom.api.domain.facility.dto.FacilityReindexResponse;
 import com.aidom.api.domain.facility.service.FacilityIndexService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
@@ -29,8 +29,8 @@ public class FacilityAdminController {
       description = "DB의 모든 시설 데이터를 Elasticsearch에 재색인합니다. 무중단 alias 스위칭 방식.")
   @ApiResponse(responseCode = "200", description = "재색인 완료")
   @PostMapping("/reindex")
-  public ResponseEntity<Map<String, Object>> reindex() {
+  public ResponseEntity<FacilityReindexResponse> reindex() {
     int count = facilityIndexService.reindexAll();
-    return ResponseEntity.ok(Map.of("indexed", count, "message", "재색인 완료"));
+    return ResponseEntity.ok(new FacilityReindexResponse(count, "재색인 완료"));
   }
 }

--- a/src/main/java/com/aidom/api/domain/facility/dto/FacilityReindexResponse.java
+++ b/src/main/java/com/aidom/api/domain/facility/dto/FacilityReindexResponse.java
@@ -1,0 +1,3 @@
+package com.aidom.api.domain.facility.dto;
+
+public record FacilityReindexResponse(int indexed, String message) {}

--- a/src/main/java/com/aidom/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/aidom/api/global/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.aidom.api.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable())
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers("/api/v1/admin/**").authenticated().anyRequest().permitAll())
+        .httpBasic(Customizer.withDefaults());
+    return http.build();
+  }
+
+  @Bean
+  public UserDetailsService userDetailsService(
+      @Value("${aidom.admin.username}") String username,
+      @Value("${aidom.admin.password}") String password) {
+    return new InMemoryUserDetailsManager(
+        User.withUsername(username).password("{noop}" + password).roles("ADMIN").build());
+  }
+}

--- a/src/main/java/com/aidom/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/aidom/api/global/config/SecurityConfig.java
@@ -6,33 +6,65 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.util.StringUtils;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain filterChain(
+      HttpSecurity http,
+      @Value("${aidom.admin.username:}") String username,
+      @Value("${aidom.admin.password:}") String password)
+      throws Exception {
     http.csrf(csrf -> csrf.disable())
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .authorizeHttpRequests(
-            auth ->
-                auth.requestMatchers("/api/v1/admin/**").authenticated().anyRequest().permitAll())
+        .authorizeHttpRequests(auth -> applyAuthorizationRules(auth, username, password))
         .httpBasic(Customizer.withDefaults());
     return http.build();
   }
 
   @Bean
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+
+  @Bean
   public UserDetailsService userDetailsService(
-      @Value("${aidom.admin.username}") String username,
-      @Value("${aidom.admin.password}") String password) {
+      @Value("${aidom.admin.username:}") String username,
+      @Value("${aidom.admin.password:}") String password) {
+    if (!isAdminConfigured(username, password)) {
+      return new InMemoryUserDetailsManager();
+    }
+
     return new InMemoryUserDetailsManager(
-        User.withUsername(username).password("{noop}" + password).roles("ADMIN").build());
+        User.withUsername(username).password(password).roles("ADMIN").build());
+  }
+
+  private void applyAuthorizationRules(
+      AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth,
+      String username,
+      String password) {
+    if (isAdminConfigured(username, password)) {
+      auth.requestMatchers("/api/v1/admin/**").hasRole("ADMIN");
+    } else {
+      auth.requestMatchers("/api/v1/admin/**").denyAll();
+    }
+
+    auth.anyRequest().permitAll();
+  }
+
+  private boolean isAdminConfigured(String username, String password) {
+    return StringUtils.hasText(username) && StringUtils.hasText(password);
   }
 }

--- a/src/main/java/com/aidom/api/global/config/SwaggerConfig.java
+++ b/src/main/java/com/aidom/api/global/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.aidom.api.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.tags.Tag;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +21,15 @@ public class SwaggerConfig {
                 .title("AIDOM Backend API")
                 .version("1.0.0")
                 .description("AIDOM Backend REST API Documentation"))
+        .components(
+            new Components()
+                .addSecuritySchemes(
+                    "basicAuth",
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("basic")
+                        .description("Admin API 인증 (아이디/비밀번호)")))
+        .addSecurityItem(new SecurityRequirement().addList("basicAuth"))
         .tags(
             List.of(
                 new Tag().name("시설 Facilities").description("시설 조회·검색·추천·필터 API"),

--- a/src/main/resources/application-integration-test.properties
+++ b/src/main/resources/application-integration-test.properties
@@ -10,3 +10,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 
 # Elasticsearch
 spring.data.elasticsearch.repositories.enabled=true
+
+# Admin
+aidom.admin.username=test
+aidom.admin.password=test

--- a/src/main/resources/application-integration-test.properties
+++ b/src/main/resources/application-integration-test.properties
@@ -13,4 +13,4 @@ spring.data.elasticsearch.repositories.enabled=true
 
 # Admin
 aidom.admin.username=test
-aidom.admin.password=test
+aidom.admin.password={noop}test

--- a/src/main/resources/application-local.example.properties
+++ b/src/main/resources/application-local.example.properties
@@ -1,5 +1,4 @@
 # Local Development - Docker Compose MySQL
-# 이 파일을 복사해서 application-local.properties 로 이름 변경 후 사용하세요.
 # cp application-local.example.properties application-local.properties
 
 spring.datasource.url=jdbc:mysql://localhost:3307/aidom

--- a/src/main/resources/application-local.example.properties
+++ b/src/main/resources/application-local.example.properties
@@ -10,3 +10,11 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+# Elasticsearch
+spring.data.elasticsearch.repositories.enabled=true
+spring.elasticsearch.uris=http://localhost:9200
+
+# Admin
+aidom.admin.username=admin
+aidom.admin.password={noop}admin

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -14,3 +14,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 # Elasticsearch
 spring.data.elasticsearch.repositories.enabled=true
 spring.elasticsearch.uris=http://localhost:9200
+
+# Admin
+aidom.admin.username=admin
+aidom.admin.password=admin

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -17,4 +17,4 @@ spring.elasticsearch.uris=http://localhost:9200
 
 # Admin
 aidom.admin.username=admin
-aidom.admin.password=admin
+aidom.admin.password={noop}admin

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -26,3 +26,7 @@ spring.data.elasticsearch.repositories.enabled=true
 spring.elasticsearch.uris=${ES_URL}
 spring.elasticsearch.username=${ES_USERNAME:}
 spring.elasticsearch.password=${ES_PASSWORD:}
+
+# Admin
+aidom.admin.username=${ADMIN_USERNAME}
+aidom.admin.password=${ADMIN_PASSWORD}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -29,4 +29,4 @@ spring.elasticsearch.password=${ES_PASSWORD:}
 
 # Admin
 aidom.admin.username=${ADMIN_USERNAME}
-aidom.admin.password=${ADMIN_PASSWORD}
+aidom.admin.password=${ADMIN_PASSWORD_ENCODED:}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -14,3 +14,7 @@ spring.autoconfigure.exclude=\
   org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration,\
   org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration
 spring.data.elasticsearch.repositories.enabled=false
+
+# Admin
+aidom.admin.username=test
+aidom.admin.password=test

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -17,4 +17,4 @@ spring.data.elasticsearch.repositories.enabled=false
 
 # Admin
 aidom.admin.username=test
-aidom.admin.password=test
+aidom.admin.password={noop}test

--- a/src/test/java/com/aidom/api/domain/facility/controller/FacilityAdminControllerTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/controller/FacilityAdminControllerTest.java
@@ -1,0 +1,51 @@
+package com.aidom.api.domain.facility.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aidom.api.domain.facility.service.FacilityIndexService;
+import com.aidom.api.global.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(FacilityAdminController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(
+    properties = {
+      "spring.data.elasticsearch.repositories.enabled=true",
+      "aidom.admin.username=admin",
+      "aidom.admin.password={noop}admin"
+    })
+class FacilityAdminControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private FacilityIndexService facilityIndexService;
+
+  @Test
+  @DisplayName("관리자 인증이 없으면 재색인 요청은 401을 반환한다")
+  void reindex_unauthorized() throws Exception {
+    mockMvc.perform(post("/api/v1/admin/facilities/reindex")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("관리자 인증이 있으면 재색인 결과를 반환한다")
+  void reindex_authorized() throws Exception {
+    given(facilityIndexService.reindexAll()).willReturn(918);
+
+    mockMvc
+        .perform(post("/api/v1/admin/facilities/reindex").with(httpBasic("admin", "admin")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.indexed").value(918))
+        .andExpect(jsonPath("$.message").value("재색인 완료"));
+  }
+}

--- a/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
@@ -14,6 +14,7 @@ import com.aidom.api.domain.facility.dto.FacilityListResponse;
 import com.aidom.api.domain.facility.dto.FacilityRecommendResponse;
 import com.aidom.api.domain.facility.dto.FacilitySearchResponse;
 import com.aidom.api.domain.facility.service.FacilityService;
+import com.aidom.api.global.config.SecurityConfig;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
 import java.math.BigDecimal;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,6 +33,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(FacilityController.class)
+@Import(SecurityConfig.class)
 @ActiveProfiles("test")
 @TestPropertySource(properties = "spring.data.elasticsearch.repositories.enabled=true")
 class FacilityControllerTest {

--- a/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
@@ -35,7 +35,12 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(FacilityController.class)
 @Import(SecurityConfig.class)
 @ActiveProfiles("test")
-@TestPropertySource(properties = "spring.data.elasticsearch.repositories.enabled=true")
+@TestPropertySource(
+    properties = {
+      "spring.data.elasticsearch.repositories.enabled=true",
+      "aidom.admin.username=test-admin",
+      "aidom.admin.password={noop}test-admin"
+    })
 class FacilityControllerTest {
 
   @Autowired private MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- Spring Security Basic Auth를 /api/v1/admin/** 경로에 적용
- 나머지 API는 permitAll 유지 (기존 동작 변경 없음)
- Swagger에 basicAuth 보안 스키마 추가
- 프로필별 admin 인증 정보 설정 (prod: 환경변수 참조)

## Test plan
- [x] FacilityControllerTest: SecurityConfig import 추가하여 WebMvcTest 정상 동작 확인
- [ ] Swagger UI에서 Authorize 버튼 클릭 후 admin 인증 테스트
- [ ] POST /api/v1/admin/facilities/reindex 인증 없이 호출 시 401 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)