### PR TITLE
feat: Implement user onboarding & withdraw

### DIFF
--- a/src/main/java/com/aidom/api/domain/user/controller/UserAccountController.java
+++ b/src/main/java/com/aidom/api/domain/user/controller/UserAccountController.java
@@ -1,0 +1,43 @@
+package com.aidom.api.domain.user.controller;
+
+import com.aidom.api.domain.user.service.UserWithdrawalService;
+import com.aidom.api.global.error.CustomException;
+import com.aidom.api.global.error.ErrorCode;
+import com.aidom.api.global.security.AuthenticatedUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "사용자 User", description = "유저 계정 API")
+@RestController
+@RequestMapping("/api/v1/users/me")
+public class UserAccountController {
+
+  private final UserWithdrawalService userWithdrawalService;
+
+  public UserAccountController(UserWithdrawalService userWithdrawalService) {
+    this.userWithdrawalService = userWithdrawalService;
+  }
+
+  @Operation(summary = "회원 탈퇴", description = "카카오 연동 해제 후 회원을 소프트 삭제합니다.")
+  @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공")
+  @ApiResponse(responseCode = "401", description = "인증 실패 또는 토큰 문제")
+  @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
+  @ApiResponse(responseCode = "422", description = "이미 탈퇴한 유저")
+  @ApiResponse(responseCode = "502", description = "카카오 연동 해제 실패")
+  @DeleteMapping
+  public ResponseEntity<Void> withdraw(
+      @AuthenticationPrincipal AuthenticatedUserPrincipal principal) {
+    if (principal == null) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED);
+    }
+
+    userWithdrawalService.withdraw(principal.userId());
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/aidom/api/domain/user/controller/UserOnboardingController.java
+++ b/src/main/java/com/aidom/api/domain/user/controller/UserOnboardingController.java
@@ -1,0 +1,55 @@
+package com.aidom.api.domain.user.controller;
+
+import com.aidom.api.domain.user.dto.UserOnboardingRequest;
+import com.aidom.api.domain.user.dto.UserOnboardingResponse;
+import com.aidom.api.domain.user.service.UserOnboardingService;
+import com.aidom.api.global.error.CustomException;
+import com.aidom.api.global.error.ErrorCode;
+import com.aidom.api.global.security.AuthenticatedUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "사용자 User", description = "유저 온보딩(회원가입 완료) API")
+@RestController
+@RequestMapping("/api/v1/users/me")
+public class UserOnboardingController {
+
+  private final UserOnboardingService userOnboardingService;
+
+  public UserOnboardingController(UserOnboardingService userOnboardingService) {
+    this.userOnboardingService = userOnboardingService;
+  }
+
+  @Operation(
+      summary = "회원가입 완료(온보딩)",
+      description = "ONBOARDING 상태의 유저가 부모/아이 정보를 저장하고 ACTIVE 상태로 전환합니다.")
+  @ApiResponse(
+      responseCode = "200",
+      description = "온보딩 완료",
+      content = @Content(schema = @Schema(implementation = UserOnboardingResponse.class)))
+  @ApiResponse(responseCode = "400", description = "요청 값 유효성 검증 실패")
+  @ApiResponse(responseCode = "401", description = "인증 실패 또는 토큰 문제")
+  @ApiResponse(responseCode = "422", description = "이미 ACTIVE 상태 등 비즈니스 규칙 위반")
+  @PostMapping("/onboarding")
+  public ResponseEntity<UserOnboardingResponse> completeOnboarding(
+      @AuthenticationPrincipal AuthenticatedUserPrincipal principal,
+      @Valid @RequestBody UserOnboardingRequest request) {
+    if (principal == null) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED);
+    }
+
+    UserOnboardingResponse response =
+        userOnboardingService.completeOnboarding(principal.userId(), request);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/aidom/api/domain/user/dto/UserOnboardingRequest.java
+++ b/src/main/java/com/aidom/api/domain/user/dto/UserOnboardingRequest.java
@@ -1,0 +1,74 @@
+package com.aidom.api.domain.user.dto;
+
+import com.aidom.api.domain.user.enums.ParentRelation;
+import com.aidom.api.global.common.entity.Gender;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.List;
+
+@Schema(description = "회원가입 완료(온보딩) 요청")
+public record UserOnboardingRequest(
+    @NotNull @Valid @Schema(description = "부모 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+        ParentInfo parentInfo,
+    @NotEmpty @Valid @Schema(description = "아이 정보 목록(현재 UI는 1명, 백엔드는 List로 다자녀 확장 지원)")
+        List<@NotNull ChildInfo> children) {
+
+  @Schema(description = "부모(유저) 정보")
+  public record ParentInfo(
+      @NotBlank
+          @Size(max = 50)
+          @Schema(
+              description = "부모 이름",
+              example = "홍길동",
+              requiredMode = Schema.RequiredMode.REQUIRED)
+          String name,
+      @NotNull
+          @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+          @Schema(
+              description = "부모 생년월일 (yyyy.MM.dd)",
+              example = "1980.01.01",
+              requiredMode = Schema.RequiredMode.REQUIRED)
+          LocalDate birthDate,
+      @NotNull
+          @Schema(
+              description = "부모와 아이의 관계 (FATHER=부, MOTHER=모, GUARDIAN=보호자(조부모, 기타))",
+              allowableValues = {"FATHER", "MOTHER", "GUARDIAN"},
+              example = "MOTHER",
+              requiredMode = Schema.RequiredMode.REQUIRED)
+          ParentRelation relation,
+      @NotBlank
+          @Size(max = 50)
+          @Schema(
+              description = "거주 자치구",
+              example = "강남구",
+              requiredMode = Schema.RequiredMode.REQUIRED)
+          String district,
+      @NotBlank
+          @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "연락처는 010-XXXX-XXXX 형식이어야 합니다.")
+          @Schema(
+              description = "연락처 (010-XXXX-XXXX 형식)",
+              example = "010-4543-8167",
+              requiredMode = Schema.RequiredMode.REQUIRED)
+          String phone) {}
+
+  @Schema(description = "아이 정보")
+  public record ChildInfo(
+      @Size(max = 50) @Schema(description = "아이 이름", example = "김아이") String name,
+      @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+          @Schema(description = "아이 생년월일 (yyyy.MM.dd)", example = "2021.03.15")
+          LocalDate birthDate,
+      @Schema(
+              description = "아이 성별 (MALE=남자, FEMALE=여자)",
+              allowableValues = {"MALE", "FEMALE"},
+              example = "MALE")
+          Gender gender,
+      @Size(max = 1000) @Schema(description = "특이사항/알레르기 메모", example = "계란 알레르기", nullable = true)
+          String specialNote) {}
+}

--- a/src/main/java/com/aidom/api/domain/user/dto/UserOnboardingRequest.java
+++ b/src/main/java/com/aidom/api/domain/user/dto/UserOnboardingRequest.java
@@ -60,14 +60,26 @@ public record UserOnboardingRequest(
 
   @Schema(description = "아이 정보")
   public record ChildInfo(
-      @Size(max = 50) @Schema(description = "아이 이름", example = "김아이") String name,
-      @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
-          @Schema(description = "아이 생년월일 (yyyy.MM.dd)", example = "2021.03.15")
+      @NotBlank
+          @Size(max = 50)
+          @Schema(
+              description = "아이 이름",
+              example = "김아이",
+              requiredMode = Schema.RequiredMode.REQUIRED)
+          String name,
+      @NotNull
+          @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+          @Schema(
+              description = "아이 생년월일 (yyyy.MM.dd)",
+              example = "2021.03.15",
+              requiredMode = Schema.RequiredMode.REQUIRED)
           LocalDate birthDate,
-      @Schema(
+      @NotNull
+          @Schema(
               description = "아이 성별 (MALE=남자, FEMALE=여자)",
               allowableValues = {"MALE", "FEMALE"},
-              example = "MALE")
+              example = "MALE",
+              requiredMode = Schema.RequiredMode.REQUIRED)
           Gender gender,
       @Size(max = 1000) @Schema(description = "특이사항/알레르기 메모", example = "계란 알레르기", nullable = true)
           String specialNote) {}

--- a/src/main/java/com/aidom/api/domain/user/dto/UserOnboardingResponse.java
+++ b/src/main/java/com/aidom/api/domain/user/dto/UserOnboardingResponse.java
@@ -1,0 +1,10 @@
+package com.aidom.api.domain.user.dto;
+
+import com.aidom.api.domain.user.enums.UserStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원가입 완료(온보딩) 응답")
+public record UserOnboardingResponse(
+    @Schema(description = "유저 ID", example = "1") Long userId,
+    @Schema(description = "변경된 유저 상태", example = "ACTIVE") UserStatus status,
+    @Schema(description = "저장된 아이 수", example = "1") int childCount) {}

--- a/src/main/java/com/aidom/api/domain/user/entity/Child.java
+++ b/src/main/java/com/aidom/api/domain/user/entity/Child.java
@@ -9,12 +9,16 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "children")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AttributeOverride(name = "id", column = @Column(name = "child_id"))
+@SQLDelete(sql = "UPDATE children SET deleted_at = CURRENT_TIMESTAMP WHERE child_id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class Child extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -53,5 +57,20 @@ public class Child extends BaseEntity {
     this.gender = gender;
     this.specialNote = specialNote;
     this.isPrimary = isPrimary;
+  }
+
+  public static Child of(
+      String name, LocalDate birthDate, Gender gender, String specialNote, boolean isPrimary) {
+    return Child.builder()
+        .name(name)
+        .birthDate(birthDate)
+        .gender(gender)
+        .specialNote(specialNote)
+        .isPrimary(isPrimary)
+        .build();
+  }
+
+  void assignUser(User user) {
+    this.user = user;
   }
 }

--- a/src/main/java/com/aidom/api/domain/user/entity/User.java
+++ b/src/main/java/com/aidom/api/domain/user/entity/User.java
@@ -15,6 +15,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
@@ -22,7 +23,9 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AttributeOverride(name = "id", column = @Column(name = "user_id"))
-@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(
+    sql = "UPDATE users SET status = 'DELETED', deleted_at = CURRENT_TIMESTAMP WHERE user_id = ?")
+@SQLRestriction("status in ('ACTIVE','ONBOARDING') and deleted_at IS NULL")
 public class User extends BaseEntity {
 
   @Column(nullable = false, length = 50)
@@ -135,5 +138,9 @@ public class User extends BaseEntity {
   public void addChild(Child child) {
     children.add(child);
     child.assignUser(this);
+  }
+
+  public boolean isWithdrawn() {
+    return status == UserStatus.DELETED || status == UserStatus.WITHDRAW;
   }
 }

--- a/src/main/java/com/aidom/api/domain/user/entity/User.java
+++ b/src/main/java/com/aidom/api/domain/user/entity/User.java
@@ -1,14 +1,16 @@
 package com.aidom.api.domain.user.entity;
 
+import com.aidom.api.domain.user.enums.ParentRelation;
 import com.aidom.api.domain.user.enums.Provider;
 import com.aidom.api.domain.user.enums.Role;
 import com.aidom.api.domain.user.enums.UserStatus;
 import com.aidom.api.global.common.entity.BaseEntity;
-import com.aidom.api.global.common.entity.Gender;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,13 +47,16 @@ public class User extends BaseEntity {
   private UserStatus status;
 
   @Enumerated(EnumType.STRING)
-  @Column
-  private Gender gender;
+  @Column(length = 20)
+  private ParentRelation relation;
 
   @Column private LocalDate birthDate;
 
   @Column(length = 20)
   private String phone;
+
+  @Column(length = 50)
+  private String city;
 
   @Column(length = 50)
   private String district;
@@ -65,6 +70,9 @@ public class User extends BaseEntity {
   @Column(precision = 10, scale = 7)
   private BigDecimal addressLng;
 
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Child> children = new ArrayList<>();
+
   private LocalDateTime deletedAt;
 
   @Builder
@@ -75,9 +83,10 @@ public class User extends BaseEntity {
       String providerId,
       Role role,
       UserStatus status,
-      Gender gender,
+      ParentRelation relation,
       LocalDate birthDate,
       String phone,
+      String city,
       String district,
       String addressDetail,
       BigDecimal addressLat,
@@ -88,9 +97,10 @@ public class User extends BaseEntity {
     this.providerId = providerId;
     this.role = role;
     this.status = status;
-    this.gender = gender;
+    this.relation = relation;
     this.birthDate = birthDate;
     this.phone = phone;
+    this.city = city;
     this.district = district;
     this.addressDetail = addressDetail;
     this.addressLat = addressLat;
@@ -104,5 +114,26 @@ public class User extends BaseEntity {
     if (email != null && !email.isBlank()) {
       this.email = email.trim();
     }
+  }
+
+  public void completeOnboarding(
+      String name,
+      LocalDate birthDate,
+      ParentRelation relation,
+      String city,
+      String district,
+      String phone) {
+    this.name = name;
+    this.birthDate = birthDate;
+    this.relation = relation;
+    this.city = city;
+    this.district = district;
+    this.phone = phone;
+    this.status = UserStatus.ACTIVE;
+  }
+
+  public void addChild(Child child) {
+    children.add(child);
+    child.assignUser(this);
   }
 }

--- a/src/main/java/com/aidom/api/domain/user/enums/ParentRelation.java
+++ b/src/main/java/com/aidom/api/domain/user/enums/ParentRelation.java
@@ -1,0 +1,7 @@
+package com.aidom.api.domain.user.enums;
+
+public enum ParentRelation {
+  FATHER,
+  MOTHER,
+  GUARDIAN
+}

--- a/src/main/java/com/aidom/api/domain/user/enums/SeoulDistrict.java
+++ b/src/main/java/com/aidom/api/domain/user/enums/SeoulDistrict.java
@@ -1,0 +1,53 @@
+package com.aidom.api.domain.user.enums;
+
+import com.aidom.api.global.error.CustomException;
+import com.aidom.api.global.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeoulDistrict {
+  GANGNAM("강남구"),
+  GANGDONG("강동구"),
+  GANGBUK("강북구"),
+  GANGSEO("강서구"),
+  GWANAK("관악구"),
+  GWANGJIN("광진구"),
+  GURO("구로구"),
+  GEUMCHEON("금천구"),
+  NOWON("노원구"),
+  DOBONG("도봉구"),
+  DONGDAEMUN("동대문구"),
+  DONGJAK("동작구"),
+  MAPO("마포구"),
+  SEODAEMUN("서대문구"),
+  SEOCHO("서초구"),
+  SEONGDONG("성동구"),
+  SEONGBUK("성북구"),
+  SONGPA("송파구"),
+  YANGCHEON("양천구"),
+  YEONGDEUNGPO("영등포구"),
+  YONGSAN("용산구"),
+  EUNPYEONG("은평구"),
+  JONGNO("종로구"),
+  JUNG("중구"),
+  JUNGNANG("중랑구");
+
+  @JsonValue private final String description;
+
+  @JsonCreator
+  public static SeoulDistrict from(String value) {
+    if (value == null || value.isBlank()) {
+      throw new CustomException(ErrorCode.INVALID_DISTRICT_VALUE);
+    }
+    String normalizedValue = value.trim();
+    return Arrays.stream(SeoulDistrict.values())
+        .filter(district -> district.description.equals(normalizedValue))
+        .findFirst()
+        .orElseThrow(() -> new CustomException(ErrorCode.INVALID_DISTRICT_VALUE));
+  }
+}

--- a/src/main/java/com/aidom/api/domain/user/enums/UserStatus.java
+++ b/src/main/java/com/aidom/api/domain/user/enums/UserStatus.java
@@ -4,5 +4,6 @@ public enum UserStatus {
   ONBOARDING,
   ACTIVE,
   INACTIVE,
-  WITHDRAW
+  WITHDRAW,
+  DELETED
 }

--- a/src/main/java/com/aidom/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/aidom/api/domain/user/repository/UserRepository.java
@@ -4,7 +4,12 @@ import com.aidom.api.domain.user.entity.User;
 import com.aidom.api.domain.user.enums.Provider;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
+
+  @Query(value = "SELECT * FROM users WHERE user_id = :userId", nativeQuery = true)
+  Optional<User> findByIdIncludingDeleted(@Param("userId") Long userId);
 }

--- a/src/main/java/com/aidom/api/domain/user/service/KakaoUnlinkClient.java
+++ b/src/main/java/com/aidom/api/domain/user/service/KakaoUnlinkClient.java
@@ -5,6 +5,7 @@ import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -16,15 +17,19 @@ import org.springframework.web.client.RestClientResponseException;
 public class KakaoUnlinkClient {
 
   private final RestClient restClient;
-  private final AppAuthProperties authProperties;
+  private final AppAuthProperties.Kakao kakaoProperties;
 
   public KakaoUnlinkClient(RestClient.Builder restClientBuilder, AppAuthProperties authProperties) {
-    this.restClient = restClientBuilder.build();
-    this.authProperties = authProperties;
+    this.kakaoProperties = authProperties.getKakao();
+
+    SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+    requestFactory.setConnectTimeout(kakaoProperties.getConnectTimeout());
+    requestFactory.setReadTimeout(kakaoProperties.getReadTimeout());
+    this.restClient = restClientBuilder.requestFactory(requestFactory).build();
   }
 
   public void unlink(Long kakaoUserId) {
-    String adminKey = authProperties.getKakao().getAdminKey();
+    String adminKey = kakaoProperties.getAdminKey();
     if (adminKey == null || adminKey.isBlank()) {
       throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
     }
@@ -36,7 +41,7 @@ public class KakaoUnlinkClient {
     try {
       restClient
           .post()
-          .uri(authProperties.getKakao().getUnlinkUri())
+          .uri(kakaoProperties.getUnlinkUri())
           .contentType(MediaType.APPLICATION_FORM_URLENCODED)
           .header("Authorization", "KakaoAK " + adminKey.trim())
           .body(form)

--- a/src/main/java/com/aidom/api/domain/user/service/KakaoUnlinkClient.java
+++ b/src/main/java/com/aidom/api/domain/user/service/KakaoUnlinkClient.java
@@ -1,0 +1,47 @@
+package com.aidom.api.domain.user.service;
+
+import com.aidom.api.global.config.AppAuthProperties;
+import com.aidom.api.global.error.CustomException;
+import com.aidom.api.global.error.ErrorCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+public class KakaoUnlinkClient {
+
+  private final RestClient restClient;
+  private final AppAuthProperties authProperties;
+
+  public KakaoUnlinkClient(RestClient.Builder restClientBuilder, AppAuthProperties authProperties) {
+    this.restClient = restClientBuilder.build();
+    this.authProperties = authProperties;
+  }
+
+  public void unlink(Long kakaoUserId) {
+    String adminKey = authProperties.getKakao().getAdminKey();
+    if (adminKey == null || adminKey.isBlank()) {
+      throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
+    }
+
+    MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+    form.add("target_id_type", "user_id");
+    form.add("target_id", String.valueOf(kakaoUserId));
+
+    try {
+      restClient
+          .post()
+          .uri(authProperties.getKakao().getUnlinkUri())
+          .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+          .header("Authorization", "KakaoAK " + adminKey.trim())
+          .body(form)
+          .retrieve()
+          .toBodilessEntity();
+    } catch (RestClientException e) {
+      throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
+    }
+  }
+}

--- a/src/main/java/com/aidom/api/domain/user/service/KakaoUnlinkClient.java
+++ b/src/main/java/com/aidom/api/domain/user/service/KakaoUnlinkClient.java
@@ -3,12 +3,14 @@ package com.aidom.api.domain.user.service;
 import com.aidom.api.global.config.AppAuthProperties;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 
 @Component
 public class KakaoUnlinkClient {
@@ -40,8 +42,23 @@ public class KakaoUnlinkClient {
           .body(form)
           .retrieve()
           .toBodilessEntity();
+    } catch (RestClientResponseException e) {
+      if (isAlreadyUnlinked(e)) {
+        return;
+      }
+      throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
     } catch (RestClientException e) {
       throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
     }
+  }
+
+  private boolean isAlreadyUnlinked(RestClientResponseException e) {
+    if (e.getStatusCode() != HttpStatus.BAD_REQUEST) {
+      return false;
+    }
+    String body = e.getResponseBodyAsString();
+    return body != null
+        && body.contains("\"code\":-101")
+        && body.contains("NotRegisteredUserException");
   }
 }

--- a/src/main/java/com/aidom/api/domain/user/service/UserOnboardingService.java
+++ b/src/main/java/com/aidom/api/domain/user/service/UserOnboardingService.java
@@ -50,7 +50,7 @@ public class UserOnboardingService {
       boolean isPrimary = i == 0;
       Child child =
           Child.of(
-              childInfo.name().trim(),
+              normalizeName(childInfo.name()),
               childInfo.birthDate(),
               childInfo.gender(),
               normalizeNote(childInfo.specialNote()),
@@ -68,5 +68,9 @@ public class UserOnboardingService {
       return null;
     }
     return note.trim();
+  }
+
+  private String normalizeName(String name) {
+    return name.trim();
   }
 }

--- a/src/main/java/com/aidom/api/domain/user/service/UserOnboardingService.java
+++ b/src/main/java/com/aidom/api/domain/user/service/UserOnboardingService.java
@@ -1,0 +1,72 @@
+package com.aidom.api.domain.user.service;
+
+import com.aidom.api.domain.user.dto.UserOnboardingRequest;
+import com.aidom.api.domain.user.dto.UserOnboardingResponse;
+import com.aidom.api.domain.user.entity.Child;
+import com.aidom.api.domain.user.entity.User;
+import com.aidom.api.domain.user.enums.SeoulDistrict;
+import com.aidom.api.domain.user.enums.UserStatus;
+import com.aidom.api.domain.user.repository.UserRepository;
+import com.aidom.api.global.error.CustomException;
+import com.aidom.api.global.error.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserOnboardingService {
+
+  private static final String SEOUL_CITY = "서울특별시";
+
+  private final UserRepository userRepository;
+
+  public UserOnboardingService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  @Transactional
+  public UserOnboardingResponse completeOnboarding(Long userId, UserOnboardingRequest request) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.ENTITY_NOT_FOUND));
+
+    if (user.getStatus() != UserStatus.ONBOARDING) {
+      throw new CustomException(ErrorCode.BUSINESS_VALIDATION_ERROR);
+    }
+
+    UserOnboardingRequest.ParentInfo parentInfo = request.parentInfo();
+    SeoulDistrict district = SeoulDistrict.from(parentInfo.district());
+
+    user.completeOnboarding(
+        parentInfo.name().trim(),
+        parentInfo.birthDate(),
+        parentInfo.relation(),
+        SEOUL_CITY,
+        district.getDescription(),
+        parentInfo.phone().trim());
+
+    for (int i = 0; i < request.children().size(); i++) {
+      UserOnboardingRequest.ChildInfo childInfo = request.children().get(i);
+      boolean isPrimary = i == 0;
+      Child child =
+          Child.of(
+              childInfo.name().trim(),
+              childInfo.birthDate(),
+              childInfo.gender(),
+              normalizeNote(childInfo.specialNote()),
+              isPrimary);
+      user.addChild(child);
+    }
+
+    userRepository.save(user);
+
+    return new UserOnboardingResponse(user.getId(), user.getStatus(), user.getChildren().size());
+  }
+
+  private String normalizeNote(String note) {
+    if (note == null || note.isBlank()) {
+      return null;
+    }
+    return note.trim();
+  }
+}

--- a/src/main/java/com/aidom/api/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/aidom/api/domain/user/service/UserWithdrawalService.java
@@ -5,8 +5,8 @@ import com.aidom.api.domain.user.enums.Provider;
 import com.aidom.api.domain.user.repository.UserRepository;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class UserWithdrawalService {
@@ -19,14 +19,13 @@ public class UserWithdrawalService {
     this.kakaoUnlinkClient = kakaoUnlinkClient;
   }
 
-  @Transactional
   public void withdraw(Long userId) {
     User user =
         userRepository
-            .findById(userId)
+            .findByIdIncludingDeleted(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.ENTITY_NOT_FOUND));
 
-    if (user.isWithdrawn()) {
+    if (user.isWithdrawn() || user.getDeletedAt() != null) {
       throw new CustomException(ErrorCode.ALREADY_WITHDRAWN_USER);
     }
 
@@ -34,7 +33,7 @@ public class UserWithdrawalService {
       kakaoUnlinkClient.unlink(parseKakaoUserId(user.getProviderId()));
     }
 
-    userRepository.delete(user);
+    softDelete(userId);
   }
 
   private Long parseKakaoUserId(String providerId) {
@@ -42,6 +41,14 @@ public class UserWithdrawalService {
       return Long.parseLong(providerId);
     } catch (NumberFormatException e) {
       throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
+    }
+  }
+
+  private void softDelete(Long userId) {
+    try {
+      userRepository.deleteById(userId);
+    } catch (EmptyResultDataAccessException e) {
+      throw new CustomException(ErrorCode.ALREADY_WITHDRAWN_USER);
     }
   }
 }

--- a/src/main/java/com/aidom/api/domain/user/service/UserWithdrawalService.java
+++ b/src/main/java/com/aidom/api/domain/user/service/UserWithdrawalService.java
@@ -1,0 +1,47 @@
+package com.aidom.api.domain.user.service;
+
+import com.aidom.api.domain.user.entity.User;
+import com.aidom.api.domain.user.enums.Provider;
+import com.aidom.api.domain.user.repository.UserRepository;
+import com.aidom.api.global.error.CustomException;
+import com.aidom.api.global.error.ErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserWithdrawalService {
+
+  private final UserRepository userRepository;
+  private final KakaoUnlinkClient kakaoUnlinkClient;
+
+  public UserWithdrawalService(UserRepository userRepository, KakaoUnlinkClient kakaoUnlinkClient) {
+    this.userRepository = userRepository;
+    this.kakaoUnlinkClient = kakaoUnlinkClient;
+  }
+
+  @Transactional
+  public void withdraw(Long userId) {
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.ENTITY_NOT_FOUND));
+
+    if (user.isWithdrawn()) {
+      throw new CustomException(ErrorCode.ALREADY_WITHDRAWN_USER);
+    }
+
+    if (user.getProvider() == Provider.KAKAO) {
+      kakaoUnlinkClient.unlink(parseKakaoUserId(user.getProviderId()));
+    }
+
+    userRepository.delete(user);
+  }
+
+  private Long parseKakaoUserId(String providerId) {
+    try {
+      return Long.parseLong(providerId);
+    } catch (NumberFormatException e) {
+      throw new CustomException(ErrorCode.KAKAO_UNLINK_FAILED);
+    }
+  }
+}

--- a/src/main/java/com/aidom/api/global/config/AppAuthProperties.java
+++ b/src/main/java/com/aidom/api/global/config/AppAuthProperties.java
@@ -44,5 +44,7 @@ public class AppAuthProperties {
   public static class Kakao {
     private String adminKey;
     private String unlinkUri = "https://kapi.kakao.com/v1/user/unlink";
+    private Duration connectTimeout = Duration.ofSeconds(2);
+    private Duration readTimeout = Duration.ofSeconds(5);
   }
 }

--- a/src/main/java/com/aidom/api/global/config/AppAuthProperties.java
+++ b/src/main/java/com/aidom/api/global/config/AppAuthProperties.java
@@ -15,6 +15,7 @@ public class AppAuthProperties {
   private Jwt jwt = new Jwt();
   private OAuth2 oAuth2 = new OAuth2();
   private Cors cors = new Cors();
+  private Kakao kakao = new Kakao();
 
   @Getter
   @Setter
@@ -36,5 +37,12 @@ public class AppAuthProperties {
   @Setter
   public static class Cors {
     private List<String> allowedOrigins = new ArrayList<>();
+  }
+
+  @Getter
+  @Setter
+  public static class Kakao {
+    private String adminKey;
+    private String unlinkUri = "https://kapi.kakao.com/v1/user/unlink";
   }
 }

--- a/src/main/java/com/aidom/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/aidom/api/global/config/SecurityConfig.java
@@ -70,7 +70,9 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/facilities/**")
                     .permitAll()
-                    .requestMatchers("/api/v1/users/me/onboarding")
+                    .requestMatchers(HttpMethod.POST, "/api/v1/users/me/onboarding")
+                    .authenticated()
+                    .requestMatchers(HttpMethod.DELETE, "/api/v1/users/me")
                     .authenticated()
                     .anyRequest()
                     .access(

--- a/src/main/java/com/aidom/api/global/error/ErrorCode.java
+++ b/src/main/java/com/aidom/api/global/error/ErrorCode.java
@@ -24,12 +24,14 @@ public enum ErrorCode {
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다."),
   EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다."),
   ACCESS_DENIED(HttpStatus.FORBIDDEN, "A004", "해당 리소스에 접근할 권한이 없습니다."),
+  KAKAO_UNLINK_FAILED(HttpStatus.BAD_GATEWAY, "A005", "카카오 연동 해제에 실패했습니다."),
 
   // Validation
   DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "V001", "이미 존재하는 데이터입니다."),
   BUSINESS_VALIDATION_ERROR(
       HttpStatus.UNPROCESSABLE_ENTITY, "V002", "비즈니스 규칙 위반 또는 처리할 수 없는 요청입니다."),
   INVALID_DISTRICT_VALUE(HttpStatus.BAD_REQUEST, "V003", "서울특별시 자치구(district) 값이 올바르지 않습니다."),
+  ALREADY_WITHDRAWN_USER(HttpStatus.UNPROCESSABLE_ENTITY, "V004", "이미 탈퇴한 사용자입니다."),
 
   // Facility
   FACILITY_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "시설을 찾을 수 없습니다."),

--- a/src/main/java/com/aidom/api/global/error/ErrorCode.java
+++ b/src/main/java/com/aidom/api/global/error/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
   DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "V001", "이미 존재하는 데이터입니다."),
   BUSINESS_VALIDATION_ERROR(
       HttpStatus.UNPROCESSABLE_ENTITY, "V002", "비즈니스 규칙 위반 또는 처리할 수 없는 요청입니다."),
+  INVALID_DISTRICT_VALUE(HttpStatus.BAD_REQUEST, "V003", "서울특별시 자치구(district) 값이 올바르지 않습니다."),
 
   // Facility
   FACILITY_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "시설을 찾을 수 없습니다."),

--- a/src/main/java/com/aidom/api/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/aidom/api/global/security/JwtAuthenticationFilter.java
@@ -49,7 +49,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         User user =
             userRepository
-                .findById(principal.userId())
+                .findByIdIncludingDeleted(principal.userId())
                 .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
 
         AuthenticatedUserPrincipal refreshedPrincipal =

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -19,6 +19,8 @@ app.auth.jwt.auth-code-validity=5m
 app.auth.oauth2.default-success-uri=${AUTH_SUCCESS_URI:http://localhost:8090/auth/callback}
 app.auth.oauth2.authorized-redirect-uris=${AUTH_REDIRECT_URIS:http://localhost:8090/auth/callback}
 app.auth.cors.allowed-origins=${AUTH_ALLOWED_ORIGINS:http://localhost:3000}
+app.auth.kakao.connect-timeout=2s
+app.auth.kakao.read-timeout=5s
 
 # Kakao OAuth2
 spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID:dummy-kakao-client-id}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -13,9 +13,9 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 # JWT and OAuth2 (local)
 app.auth.jwt.secret=${JWT_SECRET}
-app.auth.jwt.access-token-validity=30m
+app.auth.jwt.access-token-validity=1h
 app.auth.jwt.refresh-token-validity=14d
-app.auth.jwt.auth-code-validity=60s
+app.auth.jwt.auth-code-validity=5m
 app.auth.oauth2.default-success-uri=${AUTH_SUCCESS_URI:http://localhost:8090/auth/callback}
 app.auth.oauth2.authorized-redirect-uris=${AUTH_REDIRECT_URIS:http://localhost:8090/auth/callback}
 app.auth.cors.allowed-origins=${AUTH_ALLOWED_ORIGINS:http://localhost:3000}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,5 @@ app.auth.oauth2.authorized-redirect-uris=http://localhost:3000/auth/callback
 app.auth.cors.allowed-origins=http://localhost:3000
 app.auth.kakao.admin-key=${KAKAO_ADMIN_KEY:}
 app.auth.kakao.unlink-uri=https://kapi.kakao.com/v1/user/unlink
+app.auth.kakao.connect-timeout=2s
+app.auth.kakao.read-timeout=5s

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,5 @@ app.auth.jwt.auth-code-validity=60s
 app.auth.oauth2.default-success-uri=http://localhost:3000/auth/callback
 app.auth.oauth2.authorized-redirect-uris=http://localhost:3000/auth/callback
 app.auth.cors.allowed-origins=http://localhost:3000
+app.auth.kakao.admin-key=${KAKAO_ADMIN_KEY:}
+app.auth.kakao.unlink-uri=https://kapi.kakao.com/v1/user/unlink

--- a/src/test/java/com/aidom/api/domain/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/aidom/api/domain/auth/service/AuthServiceIntegrationTest.java
@@ -13,7 +13,6 @@ import com.aidom.api.domain.user.enums.Provider;
 import com.aidom.api.domain.user.enums.Role;
 import com.aidom.api.domain.user.enums.UserStatus;
 import com.aidom.api.domain.user.repository.UserRepository;
-import com.aidom.api.global.common.entity.Gender;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
 import com.aidom.api.global.security.JwtTokenProvider;
@@ -142,7 +141,6 @@ class AuthServiceIntegrationTest {
         .providerId(providerId)
         .role(Role.USER)
         .status(UserStatus.ACTIVE)
-        .gender(Gender.FEMALE)
         .birthDate(LocalDate.of(1992, 2, 2))
         .phone("01011112222")
         .district("서초구")

--- a/src/test/java/com/aidom/api/global/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/aidom/api/global/security/JwtTokenProviderTest.java
@@ -7,7 +7,6 @@ import com.aidom.api.domain.user.entity.User;
 import com.aidom.api.domain.user.enums.Provider;
 import com.aidom.api.domain.user.enums.Role;
 import com.aidom.api.domain.user.enums.UserStatus;
-import com.aidom.api.global.common.entity.Gender;
 import com.aidom.api.global.config.AppAuthProperties;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
@@ -65,7 +64,6 @@ class JwtTokenProviderTest {
             .providerId("kakao-123")
             .role(Role.USER)
             .status(UserStatus.ACTIVE)
-            .gender(Gender.MALE)
             .birthDate(LocalDate.of(1990, 1, 1))
             .phone("01012345678")
             .district("강남구")


### PR DESCRIPTION
## 관련 이슈
Closes #34 

## 작업 내용
어떤 작업을 했는지 간략하게 설명해주세요.

## 변경 사항
- user domain에서 개발 진행
- /api/v1/user/me/onboarding 구현
- /api/v1/user/me/withdraw 구현
- 수동 swagger 테스트를 위해 local.properties의 auth-code validity 시간 증가

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [x] 관련 서비스 동작을 확인했는가?
