### PR TITLE
fix: FacilityControllerTest 컨텍스트 로딩 실패 수정

### DIFF
--- a/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
@@ -16,12 +16,16 @@ import com.aidom.api.domain.facility.dto.FacilitySearchResponse;
 import com.aidom.api.domain.facility.service.FacilityService;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
+import com.aidom.api.support.WebMvcTestSecurityConfig;
 import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,7 +34,14 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(FacilityController.class)
+@WebMvcTest(
+    controllers = FacilityController.class,
+    excludeFilters =
+        @ComponentScan.Filter(
+            type = FilterType.REGEX,
+            pattern =
+                ".*ElasticsearchConfig.*|.*SecurityConfig.*|.*JwtAuthentication.*|.*OAuth2.*|.*ProblemDetail.*"))
+@Import(WebMvcTestSecurityConfig.class)
 @ActiveProfiles("test")
 @TestPropertySource(properties = "spring.data.elasticsearch.repositories.enabled=true")
 class FacilityControllerTest {


### PR DESCRIPTION
## Summary
- `FacilityControllerTest`에서 `@WebMvcTest` 컨텍스트 로딩 실패 수정
- `ElasticsearchConfig`가 `@TestPropertySource`에 의해 활성화되어 ES 연결 시도하는 문제 해결
- `JwtAuthenticationFilter` → `JwtTokenProvider` 빈 의존성 오류 해결
- `excludeFilters`로 ES/Security 컴포넌트 제외 + `@Import(WebMvcTestSecurityConfig.class)` 적용

## Test plan
- [x] `FacilityControllerTest` 10개 케이스 전체 통과
- [x] `./gradlew test` 전체 통과 (119 tests)