### PR TITLE
chore: Swagger UI JWT 인증 지원

### DIFF
--- a/src/main/java/com/aidom/api/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/aidom/api/domain/bookmark/controller/BookmarkController.java
@@ -8,6 +8,7 @@ import com.aidom.api.global.security.AuthenticatedUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "찜 Bookmarks", description = "시설 찜(북마크) API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequiredArgsConstructor
 public class BookmarkController {

--- a/src/main/java/com/aidom/api/domain/user/controller/UserAccountController.java
+++ b/src/main/java/com/aidom/api/domain/user/controller/UserAccountController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "사용자 User", description = "유저 계정 API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/api/v1/users/me")
 public class UserAccountController {

--- a/src/main/java/com/aidom/api/domain/user/controller/UserOnboardingController.java
+++ b/src/main/java/com/aidom/api/domain/user/controller/UserOnboardingController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "사용자 User", description = "유저 온보딩(회원가입 완료) API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/api/v1/users/me")
 public class UserOnboardingController {

--- a/src/main/java/com/aidom/api/domain/user/entity/ProvisionedProfile.java
+++ b/src/main/java/com/aidom/api/domain/user/entity/ProvisionedProfile.java
@@ -1,0 +1,27 @@
+package com.aidom.api.domain.user.entity;
+
+import com.aidom.api.domain.user.enums.ParentRelation;
+import com.aidom.api.domain.user.enums.Provider;
+import com.aidom.api.domain.user.enums.Role;
+import com.aidom.api.domain.user.enums.UserStatus;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record ProvisionedProfile(
+    String name,
+    String email,
+    Provider provider,
+    String providerId,
+    Role role,
+    UserStatus status,
+    ParentRelation relation,
+    LocalDate birthDate,
+    String phone,
+    String address,
+    String city,
+    String district,
+    String addressDetail,
+    BigDecimal addressLat,
+    BigDecimal addressLng) {}

--- a/src/main/java/com/aidom/api/domain/user/entity/User.java
+++ b/src/main/java/com/aidom/api/domain/user/entity/User.java
@@ -117,6 +117,25 @@ public class User extends BaseEntity {
     this.addressLng = addressLng;
   }
 
+  public void applyProvisionedProfile(ProvisionedProfile profile) {
+    this.name = profile.name();
+    this.email = profile.email();
+    this.provider = profile.provider();
+    this.providerId = profile.providerId();
+    this.role = profile.role();
+    this.status = profile.status();
+    this.relation = profile.relation();
+    this.birthDate = profile.birthDate();
+    this.phone = profile.phone();
+    this.address = profile.address();
+    this.city = profile.city();
+    this.district = profile.district();
+    this.addressDetail = profile.addressDetail();
+    this.addressLat = profile.addressLat();
+    this.addressLng = profile.addressLng();
+    this.deletedAt = null;
+  }
+
   public void updateSocialProfile(String name, String email) {
     if (name != null && !name.isBlank()) {
       this.name = name.trim();

--- a/src/main/java/com/aidom/api/domain/visit/controller/VisitController.java
+++ b/src/main/java/com/aidom/api/domain/visit/controller/VisitController.java
@@ -12,6 +12,7 @@ import com.aidom.api.global.security.AuthenticatedUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.YearMonth;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "이용내역 Visits", description = "시설 이용내역 관리 API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequiredArgsConstructor
 public class VisitController {

--- a/src/main/java/com/aidom/api/global/config/SwaggerConfig.java
+++ b/src/main/java/com/aidom/api/global/config/SwaggerConfig.java
@@ -1,7 +1,9 @@
 package com.aidom.api.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.tags.Tag;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
@@ -10,14 +12,24 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
+  public static final String BEARER_SCHEME = "bearerAuth";
+
   @Bean
   public OpenAPI openAPI() {
+    SecurityScheme bearerScheme =
+        new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .description("JWT Access Token을 입력하세요 (Bearer 접두사 불필요)");
+
     return new OpenAPI()
         .info(
             new Info()
                 .title("AIDOM Backend API")
                 .version("1.0.0")
                 .description("AIDOM Backend REST API Documentation"))
+        .components(new Components().addSecuritySchemes(BEARER_SCHEME, bearerScheme))
         .tags(
             List.of(
                 new Tag().name("시설 Facilities").description("시설 조회·검색·추천·필터 API"),


### PR DESCRIPTION
## Summary
- Swagger UI에 JWT Bearer 인증 스킴 추가 (Authorize 버튼으로 토큰 입력 후 인증된 API 테스트 가능)
- `User.applyProvisionedProfile()` 메서드 추가 (`TestAccountBootstrapRunner` 컴파일 오류 해결)

## Test plan
- [ ] Swagger UI (`/swagger-ui/index.html`) 접속 → 우측 상단 Authorize 버튼 확인
- [ ] JWT 토큰 입력 후 인증 필요 API 정상 호출 확인
- [ ] `./gradlew test` 전체 통과 확인