### PR TITLE
feat: 이용내역 등록 시 날짜/시간 입력 지원

### DIFF
--- a/src/main/java/com/aidom/api/domain/visit/dto/VisitCreateRequest.java
+++ b/src/main/java/com/aidom/api/domain/visit/dto/VisitCreateRequest.java
@@ -3,9 +3,14 @@ package com.aidom.api.domain.visit.dto;
 import com.aidom.api.domain.visit.enums.VisitSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Schema(description = "이용내역 등록 요청 (문의 기록)")
 public record VisitCreateRequest(
     @Schema(description = "시설 ID", example = "FAC001") @NotNull String facilityId,
     @Schema(description = "아이 ID", example = "1") @NotNull Long childId,
-    @Schema(description = "등록 경로", example = "MANUAL") @NotNull VisitSource source) {}
+    @Schema(description = "등록 경로", example = "MANUAL") @NotNull VisitSource source,
+    @Schema(description = "이용 예정일", example = "2026-05-10") LocalDate visitDate,
+    @Schema(description = "시작 시간", example = "10:00") LocalTime startTime,
+    @Schema(description = "종료 시간", example = "12:00") LocalTime endTime) {}

--- a/src/main/java/com/aidom/api/domain/visit/service/VisitService.java
+++ b/src/main/java/com/aidom/api/domain/visit/service/VisitService.java
@@ -92,6 +92,9 @@ public class VisitService {
             .facility(facility)
             .status(VisitStatus.PLANNED)
             .source(request.source())
+            .visitDate(request.visitDate())
+            .startTime(request.startTime())
+            .endTime(request.endTime())
             .build();
 
     return toVisitResponse(visitHistoryRepository.save(visitHistory));

--- a/src/test/java/com/aidom/api/domain/visit/controller/VisitControllerTest.java
+++ b/src/test/java/com/aidom/api/domain/visit/controller/VisitControllerTest.java
@@ -90,7 +90,8 @@ class VisitControllerTest {
   @Test
   @DisplayName("이용내역 등록 - 정상 요청 시 201")
   void createVisit_validRequest_returns201() throws Exception {
-    VisitCreateRequest request = new VisitCreateRequest("FAC001", 1L, VisitSource.MANUAL);
+    VisitCreateRequest request =
+        new VisitCreateRequest("FAC001", 1L, VisitSource.MANUAL, null, null, null);
     given(visitService.createVisit(anyLong(), any(VisitCreateRequest.class)))
         .willReturn(sampleVisitResponse());
 

--- a/src/test/java/com/aidom/api/domain/visit/service/VisitServiceTest.java
+++ b/src/test/java/com/aidom/api/domain/visit/service/VisitServiceTest.java
@@ -58,7 +58,8 @@ class VisitServiceTest {
     User user = createUser();
     Child child = createChild(user);
     Facility facility = createFacility("FAC001");
-    VisitCreateRequest request = new VisitCreateRequest("FAC001", 1L, VisitSource.MANUAL);
+    VisitCreateRequest request =
+        new VisitCreateRequest("FAC001", 1L, VisitSource.MANUAL, null, null, null);
 
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
     given(childRepository.findById(1L)).willReturn(Optional.of(child));
@@ -79,7 +80,8 @@ class VisitServiceTest {
     User user = createUser();
     User otherUser = createOtherUser();
     Child otherChild = createChild(otherUser);
-    VisitCreateRequest request = new VisitCreateRequest("FAC001", 2L, VisitSource.MANUAL);
+    VisitCreateRequest request =
+        new VisitCreateRequest("FAC001", 2L, VisitSource.MANUAL, null, null, null);
 
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
     given(childRepository.findById(2L)).willReturn(Optional.of(otherChild));


### PR DESCRIPTION
## Summary
- `VisitCreateRequest`에 `visitDate`, `startTime`, `endTime` 필드 추가 (optional)
- `VisitService.createVisit()`에서 해당 필드를 빌더에 반영
- yearMonth 필터 조회 시 visitDate가 null이면 결과에서 누락되는 문제 해결

## Test plan
- [x] `VisitServiceTest` 통과 확인
- [x] `VisitControllerTest` 통과 확인
- [ ] Swagger에서 이용내역 등록 시 visitDate 포함하여 요청 → yearMonth 필터로 조회 확인