### PR TITLE
feat: AI 추천 시스템 개인화 고도화

### DIFF
--- a/src/main/java/com/aidom/api/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/aidom/api/domain/bookmark/repository/BookmarkRepository.java
@@ -2,6 +2,7 @@ package com.aidom.api.domain.bookmark.repository;
 
 import com.aidom.api.domain.bookmark.entity.Bookmark;
 import com.aidom.api.domain.bookmark.enums.BookmarkStatus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -24,4 +25,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
   boolean existsByUserIdAndFacilityIdAndStatus(
       Long userId, String facilityId, BookmarkStatus status);
+
+  @Query("SELECT b.facility.id FROM Bookmark b WHERE b.user.id = :userId AND b.status = 'ACTIVE'")
+  List<String> findFacilityIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/aidom/api/domain/facility/dto/FacilityRecommendResponse.java
+++ b/src/main/java/com/aidom/api/domain/facility/dto/FacilityRecommendResponse.java
@@ -2,6 +2,7 @@ package com.aidom.api.domain.facility.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
+import java.util.List;
 
 @Schema(description = "AI 추천 시설 응답")
 public record FacilityRecommendResponse(
@@ -11,4 +12,5 @@ public record FacilityRecommendResponse(
     @Schema(description = "자치구명", example = "강남구") String districtName,
     @Schema(description = "평균 평점", example = "4.5") BigDecimal avgRating,
     @Schema(description = "썸네일 URL") String thumbnailUrl,
-    @Schema(description = "추천 사유", example = "아이 연령대에 적합한 프로그램이 있어요") String recommendReason) {}
+    @Schema(description = "추천 사유", example = "아이 연령대에 적합한 프로그램이 있어요") String recommendReason,
+    @Schema(description = "추천 태그", example = "[\"우리동네\", \"무료\", \"인기\"]") List<String> tags) {}

--- a/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepository.java
+++ b/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepository.java
@@ -3,6 +3,7 @@ package com.aidom.api.domain.facility.repository;
 import com.aidom.api.domain.facility.document.FacilityDocument;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -25,7 +26,14 @@ public interface FacilitySearchCustomRepository {
 
   List<FacilityDocument> searchNearby(double lat, double lng, double radiusKm, int limit);
 
-  List<FacilityDocument> recommendByChildAge(int childAge, Double lat, Double lng, int limit);
+  List<FacilityDocument> recommendByChildAge(
+      int childAge,
+      Double lat,
+      Double lng,
+      Set<String> excludeFacilityIds,
+      Set<String> preferredServiceTypes,
+      String userDistrict,
+      int limit);
 
   List<String> getDistinctDistrictNames();
 }

--- a/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepositoryImpl.java
+++ b/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepositoryImpl.java
@@ -259,8 +259,7 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
                           // 4. 무료 시설 가산점 (신규)
                           fs.functions(
                               fn ->
-                                  fn.filter(
-                                          f -> f.term(t -> t.field("isFree").value(true)))
+                                  fn.filter(f -> f.term(t -> t.field("isFree").value(true)))
                                       .weight(1.5));
 
                           // 5. 거리 감쇠 (기존)

--- a/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepositoryImpl.java
+++ b/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.aidom.api.domain.facility.document.FacilityDocument;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -158,7 +159,13 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
 
   @Override
   public List<FacilityDocument> recommendByChildAge(
-      int childAge, Double lat, Double lng, int limit) {
+      int childAge,
+      Double lat,
+      Double lng,
+      Set<String> excludeFacilityIds,
+      Set<String> preferredServiceTypes,
+      String userDistrict,
+      int limit) {
 
     NativeQuery query =
         NativeQuery.builder()
@@ -169,26 +176,38 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
                           fs.query(
                               mq ->
                                   mq.bool(
-                                      b ->
-                                          b.filter(
-                                                  f ->
-                                                      f.range(
-                                                          r ->
-                                                              r.number(
-                                                                  n ->
-                                                                      n.field("ageMin")
-                                                                          .lte((double) childAge))))
-                                              .filter(
-                                                  f ->
-                                                      f.range(
-                                                          r ->
-                                                              r.number(
-                                                                  n ->
-                                                                      n.field("ageMax")
-                                                                          .gte(
-                                                                              (double)
-                                                                                  childAge))))));
+                                      b -> {
+                                        b.filter(
+                                            f ->
+                                                f.range(
+                                                    r ->
+                                                        r.number(
+                                                            n ->
+                                                                n.field("ageMin")
+                                                                    .lte((double) childAge))));
+                                        b.filter(
+                                            f ->
+                                                f.range(
+                                                    r ->
+                                                        r.number(
+                                                            n ->
+                                                                n.field("ageMax")
+                                                                    .gte((double) childAge))));
 
+                                        if (excludeFacilityIds != null
+                                            && !excludeFacilityIds.isEmpty()) {
+                                          b.mustNot(
+                                              mn ->
+                                                  mn.ids(
+                                                      ids ->
+                                                          ids.values(
+                                                              excludeFacilityIds.stream()
+                                                                  .toList())));
+                                        }
+                                        return b;
+                                      }));
+
+                          // 1. 평점 가중치 (기존)
                           fs.functions(
                               fn ->
                                   fn.fieldValueFactor(
@@ -200,6 +219,51 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
                                                       .FieldValueFactorModifier.Log1p)
                                               .missing(0.0)));
 
+                          // 2. 자치구 친밀도 (신규)
+                          if (userDistrict != null && !userDistrict.isBlank()) {
+                            fs.functions(
+                                fn ->
+                                    fn.filter(
+                                            f ->
+                                                f.term(
+                                                    t ->
+                                                        t.field("districtName")
+                                                            .value(userDistrict)))
+                                        .weight(3.0));
+                          }
+
+                          // 3. 서비스 유형 선호도 (신규)
+                          if (preferredServiceTypes != null && !preferredServiceTypes.isEmpty()) {
+                            fs.functions(
+                                fn ->
+                                    fn.filter(
+                                            f ->
+                                                f.terms(
+                                                    t ->
+                                                        t.field("serviceType")
+                                                            .terms(
+                                                                tv ->
+                                                                    tv.value(
+                                                                        preferredServiceTypes
+                                                                            .stream()
+                                                                            .map(
+                                                                                co.elastic.clients
+                                                                                        .elasticsearch
+                                                                                        ._types
+                                                                                        .FieldValue
+                                                                                    ::of)
+                                                                            .toList()))))
+                                        .weight(2.0));
+                          }
+
+                          // 4. 무료 시설 가산점 (신규)
+                          fs.functions(
+                              fn ->
+                                  fn.filter(
+                                          f -> f.term(t -> t.field("isFree").value(true)))
+                                      .weight(1.5));
+
+                          // 5. 거리 감쇠 (기존)
                           if (lat != null && lng != null) {
                             fs.functions(
                                 fn ->

--- a/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
@@ -1,5 +1,6 @@
 package com.aidom.api.domain.facility.service;
 
+import com.aidom.api.domain.bookmark.repository.BookmarkRepository;
 import com.aidom.api.domain.facility.document.FacilityDocument;
 import com.aidom.api.domain.facility.dto.FacilityDetailResponse;
 import com.aidom.api.domain.facility.dto.FacilityFilterResponse;
@@ -13,14 +14,20 @@ import com.aidom.api.domain.facility.enums.ServiceType;
 import com.aidom.api.domain.facility.repository.FacilityRepository;
 import com.aidom.api.domain.facility.repository.FacilitySearchRepository;
 import com.aidom.api.domain.user.entity.Child;
+import com.aidom.api.domain.user.entity.User;
 import com.aidom.api.domain.user.service.ChildService;
+import com.aidom.api.domain.visit.repository.VisitHistoryRepository;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
@@ -40,6 +47,8 @@ public class FacilityService {
   private final FacilitySearchRepository facilitySearchRepository;
   private final FacilityRepository facilityRepository;
   private final ChildService childService;
+  private final BookmarkRepository bookmarkRepository;
+  private final VisitHistoryRepository visitHistoryRepository;
 
   public Page<FacilityListResponse> listFacilities(
       String districtName,
@@ -90,16 +99,45 @@ public class FacilityService {
       Long childId, BigDecimal lat, BigDecimal lng, int limit) {
 
     Child child = childService.getChildById(childId);
-
+    User user = child.getUser();
     int childAge = calculateAge(child.getBirthDate());
 
+    // 찜한 시설 ID 및 서비스 유형 조회
+    List<String> bookmarkedFacilityIds = bookmarkRepository.findFacilityIdsByUserId(user.getId());
+    Set<String> preferredServiceTypes;
+    if (!bookmarkedFacilityIds.isEmpty()) {
+      preferredServiceTypes =
+          facilityRepository.findAllById(bookmarkedFacilityIds).stream()
+              .map(f -> f.getServiceType().getDescription())
+              .collect(Collectors.toSet());
+    } else {
+      preferredServiceTypes = Set.of();
+    }
+
+    // 방문한 시설 ID 조회 (제외 대상)
+    List<String> visitedFacilityIds = visitHistoryRepository.findFacilityIdsByUserId(user.getId());
+    Set<String> excludeFacilityIds = new HashSet<>(visitedFacilityIds);
+
+    // 위치 미제공 시 사용자 주소 기본값 사용
     Double latVal = lat != null ? lat.doubleValue() : null;
     Double lngVal = lng != null ? lng.doubleValue() : null;
+    if (latVal == null && user.getAddressLat() != null) {
+      latVal = user.getAddressLat().doubleValue();
+    }
+    if (lngVal == null && user.getAddressLng() != null) {
+      lngVal = user.getAddressLng().doubleValue();
+    }
+
+    String userDistrict = user.getDistrict();
 
     List<FacilityDocument> docs =
-        facilitySearchRepository.recommendByChildAge(childAge, latVal, lngVal, limit);
+        facilitySearchRepository.recommendByChildAge(
+            childAge, latVal, lngVal, excludeFacilityIds, preferredServiceTypes, userDistrict,
+            limit);
 
-    return docs.stream().map(doc -> toRecommendResponse(doc, childAge)).toList();
+    return docs.stream()
+        .map(doc -> toRecommendResponse(doc, childAge, userDistrict, preferredServiceTypes))
+        .toList();
   }
 
   public List<FacilityListResponse> getNearbyFacilities(
@@ -216,9 +254,35 @@ public class FacilityService {
         stats != null ? stats.getReviewCount() : 0);
   }
 
-  private FacilityRecommendResponse toRecommendResponse(FacilityDocument doc, int childAge) {
+  private FacilityRecommendResponse toRecommendResponse(
+      FacilityDocument doc, int childAge, String userDistrict, Set<String> preferredServiceTypes) {
+
+    List<String> tags = new ArrayList<>();
     String reason =
         String.format("%d세 아이에게 적합한 시설이에요 (%d~%d세 대상)", childAge, doc.getAgeMin(), doc.getAgeMax());
+
+    if (userDistrict != null && userDistrict.equals(doc.getDistrictName())) {
+      reason = String.format("우리 동네(%s)에 있는 추천 시설이에요", userDistrict);
+      tags.add("우리동네");
+    }
+
+    if (preferredServiceTypes != null && preferredServiceTypes.contains(doc.getServiceType())) {
+      if (tags.isEmpty()) {
+        reason = "찜한 시설과 비슷한 유형이에요";
+      }
+      tags.add("관심유형");
+    }
+
+    if (doc.isFree()) {
+      if (tags.isEmpty()) {
+        reason = "무료로 이용 가능해요";
+      }
+      tags.add("무료");
+    }
+
+    if (doc.getAvgRating() >= 4.0) {
+      tags.add("인기");
+    }
 
     return new FacilityRecommendResponse(
         doc.getId(),
@@ -227,6 +291,7 @@ public class FacilityService {
         doc.getDistrictName(),
         BigDecimal.valueOf(doc.getAvgRating()),
         null,
-        reason);
+        reason,
+        tags);
   }
 }

--- a/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
@@ -132,7 +132,12 @@ public class FacilityService {
 
     List<FacilityDocument> docs =
         facilitySearchRepository.recommendByChildAge(
-            childAge, latVal, lngVal, excludeFacilityIds, preferredServiceTypes, userDistrict,
+            childAge,
+            latVal,
+            lngVal,
+            excludeFacilityIds,
+            preferredServiceTypes,
+            userDistrict,
             limit);
 
     return docs.stream()

--- a/src/main/java/com/aidom/api/domain/visit/dto/VisitCreateRequest.java
+++ b/src/main/java/com/aidom/api/domain/visit/dto/VisitCreateRequest.java
@@ -3,9 +3,14 @@ package com.aidom.api.domain.visit.dto;
 import com.aidom.api.domain.visit.enums.VisitSource;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Schema(description = "이용내역 등록 요청 (문의 기록)")
 public record VisitCreateRequest(
     @Schema(description = "시설 ID", example = "FAC001") @NotNull String facilityId,
     @Schema(description = "아이 ID", example = "1") @NotNull Long childId,
-    @Schema(description = "등록 경로", example = "MANUAL") @NotNull VisitSource source) {}
+    @Schema(description = "등록 경로", example = "MANUAL") @NotNull VisitSource source,
+    @Schema(description = "이용 예정일", example = "2026-05-10") LocalDate visitDate,
+    @Schema(description = "시작 시간", example = "10:00") LocalTime startTime,
+    @Schema(description = "종료 시간", example = "12:00") LocalTime endTime) {}

--- a/src/main/java/com/aidom/api/domain/visit/repository/VisitHistoryRepository.java
+++ b/src/main/java/com/aidom/api/domain/visit/repository/VisitHistoryRepository.java
@@ -62,4 +62,9 @@ public interface VisitHistoryRepository extends JpaRepository<VisitHistory, Long
       @Param("userId") Long userId,
       @Param("statuses") List<VisitStatus> statuses,
       Pageable pageable);
+
+  @Query(
+      "SELECT DISTINCT v.facility.id FROM VisitHistory v"
+          + " WHERE v.user.id = :userId AND v.status <> 'CANCELLED'")
+  List<String> findFacilityIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/aidom/api/domain/visit/service/VisitService.java
+++ b/src/main/java/com/aidom/api/domain/visit/service/VisitService.java
@@ -92,6 +92,9 @@ public class VisitService {
             .facility(facility)
             .status(VisitStatus.PLANNED)
             .source(request.source())
+            .visitDate(request.visitDate())
+            .startTime(request.startTime())
+            .endTime(request.endTime())
             .build();
 
     return toVisitResponse(visitHistoryRepository.save(visitHistory));

--- a/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/controller/FacilityControllerTest.java
@@ -203,7 +203,8 @@ class FacilityControllerTest {
             "강남구",
             new BigDecimal("4.5"),
             null,
-            "7세 아이에게 적합한 시설이에요 (3~12세 대상)");
+            "7세 아이에게 적합한 시설이에요 (3~12세 대상)",
+            List.of("인기"));
 
     given(facilityService.recommendFacilities(eq(1L), isNull(), isNull(), eq(5)))
         .willReturn(List.of(response));

--- a/src/test/java/com/aidom/api/domain/facility/repository/FacilitySearchRepositoryIntegrationTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/repository/FacilitySearchRepositoryIntegrationTest.java
@@ -307,7 +307,7 @@ class FacilitySearchRepositoryIntegrationTest {
   void recommendByChildAge_returnsMatchingFacilities() {
     // 7세 아이 → FAC001(3~12), FAC002(5~15), FAC003(6~13) 모두 매칭
     List<FacilityDocument> results =
-        facilitySearchRepository.recommendByChildAge(7, null, null, 10);
+        facilitySearchRepository.recommendByChildAge(7, null, null, null, null, null, 10);
 
     assertThat(results).hasSize(3);
   }
@@ -317,7 +317,7 @@ class FacilitySearchRepositoryIntegrationTest {
   void recommendByChildAge_noMatch() {
     // 20세 → 모든 시설의 ageMax보다 큼
     List<FacilityDocument> results =
-        facilitySearchRepository.recommendByChildAge(20, null, null, 10);
+        facilitySearchRepository.recommendByChildAge(20, null, null, null, null, null, 10);
 
     assertThat(results).isEmpty();
   }
@@ -326,7 +326,7 @@ class FacilitySearchRepositoryIntegrationTest {
   @DisplayName("recommendByChildAge - 위치 기반 decay가 적용된다")
   void recommendByChildAge_withLocation() {
     List<FacilityDocument> results =
-        facilitySearchRepository.recommendByChildAge(7, 37.5665, 126.978, 10);
+        facilitySearchRepository.recommendByChildAge(7, 37.5665, 126.978, null, null, null, 10);
 
     assertThat(results).isNotEmpty();
   }
@@ -400,7 +400,7 @@ class FacilitySearchRepositoryIntegrationTest {
   void recommendByChildAge_orderedByRating() {
     // 7세: 3개 모두 매칭, avgRating: FAC001=4.5 > FAC002=4.2 > FAC003=3.8
     List<FacilityDocument> results =
-        facilitySearchRepository.recommendByChildAge(7, null, null, 10);
+        facilitySearchRepository.recommendByChildAge(7, null, null, null, null, null, 10);
 
     assertThat(results).hasSize(3);
     assertThat(results.get(0).getId()).isEqualTo("FAC001");

--- a/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
@@ -3,7 +3,6 @@ package com.aidom.api.domain.facility.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
@@ -3,10 +3,12 @@ package com.aidom.api.domain.facility.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 
+import com.aidom.api.domain.bookmark.repository.BookmarkRepository;
 import com.aidom.api.domain.facility.document.FacilityDocument;
 import com.aidom.api.domain.facility.dto.FacilityDetailResponse;
 import com.aidom.api.domain.facility.dto.FacilityFilterResponse;
@@ -18,7 +20,12 @@ import com.aidom.api.domain.facility.enums.ServiceType;
 import com.aidom.api.domain.facility.repository.FacilityRepository;
 import com.aidom.api.domain.facility.repository.FacilitySearchRepository;
 import com.aidom.api.domain.user.entity.Child;
+import com.aidom.api.domain.user.entity.User;
+import com.aidom.api.domain.user.enums.Provider;
+import com.aidom.api.domain.user.enums.Role;
+import com.aidom.api.domain.user.enums.UserStatus;
 import com.aidom.api.domain.user.service.ChildService;
+import com.aidom.api.domain.visit.repository.VisitHistoryRepository;
 import com.aidom.api.global.common.entity.Gender;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
@@ -26,6 +33,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +52,8 @@ class FacilityServiceTest {
   @Mock private FacilitySearchRepository facilitySearchRepository;
   @Mock private FacilityRepository facilityRepository;
   @Mock private ChildService childService;
+  @Mock private BookmarkRepository bookmarkRepository;
+  @Mock private VisitHistoryRepository visitHistoryRepository;
 
   @InjectMocks private FacilityService facilityService;
 
@@ -117,23 +127,38 @@ class FacilityServiceTest {
   @Test
   @DisplayName("아이 나이 기반으로 시설을 추천한다")
   void recommendFacilities_mapsResult() {
+    User user =
+        User.builder()
+            .name("테스트유저")
+            .email("test@test.com")
+            .provider(Provider.KAKAO)
+            .providerId("12345")
+            .role(Role.USER)
+            .status(UserStatus.ACTIVE)
+            .district("강남구")
+            .build();
     Child child =
         Child.builder()
+            .user(user)
             .name("테스트")
             .birthDate(LocalDate.now().minusYears(7))
             .gender(Gender.MALE)
             .build();
     given(childService.getChildById(1L)).willReturn(child);
+    given(bookmarkRepository.findFacilityIdsByUserId(any())).willReturn(List.of());
+    given(visitHistoryRepository.findFacilityIdsByUserId(any())).willReturn(List.of());
 
     FacilityDocument doc = createDocument("FAC001", "강남 키움센터");
-    given(facilitySearchRepository.recommendByChildAge(eq(7), isNull(), isNull(), eq(5)))
+    given(
+            facilitySearchRepository.recommendByChildAge(
+                eq(7), isNull(), isNull(), any(Set.class), any(Set.class), eq("강남구"), eq(5)))
         .willReturn(List.of(doc));
 
     List<FacilityRecommendResponse> result = facilityService.recommendFacilities(1L, null, null, 5);
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).id()).isEqualTo("FAC001");
-    assertThat(result.get(0).recommendReason()).contains("7세");
+    assertThat(result.get(0).tags()).isNotNull();
   }
 
   @Test

--- a/src/test/java/com/aidom/api/domain/visit/controller/VisitControllerTest.java
+++ b/src/test/java/com/aidom/api/domain/visit/controller/VisitControllerTest.java
@@ -90,7 +90,8 @@ class VisitControllerTest {
   @Test
   @DisplayName("이용내역 등록 - 정상 요청 시 201")
   void createVisit_validRequest_returns201() throws Exception {
-    VisitCreateRequest request = new VisitCreateRequest("FAC001", 1L, VisitSource.MANUAL);
+    VisitCreateRequest request =
+        new VisitCreateRequest("FAC001", 1L, VisitSource.MANUAL, null, null, null);
     given(visitService.createVisit(anyLong(), any(VisitCreateRequest.class)))
         .willReturn(sampleVisitResponse());
 

--- a/src/test/java/com/aidom/api/domain/visit/service/VisitServiceTest.java
+++ b/src/test/java/com/aidom/api/domain/visit/service/VisitServiceTest.java
@@ -58,7 +58,8 @@ class VisitServiceTest {
     User user = createUser();
     Child child = createChild(user);
     Facility facility = createFacility("FAC001");
-    VisitCreateRequest request = new VisitCreateRequest("FAC001", 1L, VisitSource.MANUAL);
+    VisitCreateRequest request =
+        new VisitCreateRequest("FAC001", 1L, VisitSource.MANUAL, null, null, null);
 
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
     given(childRepository.findById(1L)).willReturn(Optional.of(child));
@@ -79,7 +80,8 @@ class VisitServiceTest {
     User user = createUser();
     User otherUser = createOtherUser();
     Child otherChild = createChild(otherUser);
-    VisitCreateRequest request = new VisitCreateRequest("FAC001", 2L, VisitSource.MANUAL);
+    VisitCreateRequest request =
+        new VisitCreateRequest("FAC001", 2L, VisitSource.MANUAL, null, null, null);
 
     given(userRepository.findById(userId)).willReturn(Optional.of(user));
     given(childRepository.findById(2L)).willReturn(Optional.of(otherChild));


### PR DESCRIPTION
## Summary
- 사용자 행동 데이터(찜, 이용내역)와 프로필 정보를 활용한 **개인화 추천 엔진** 구현
- Elasticsearch `function_score` 쿼리에 **5가지 스코어링 요소** 적용 (평점 가중치, 자치구 친밀도, 서비스 유형 선호도, 무료 시설 가산점, 거리 감쇠)
- 이미 방문한 시설을 추천 결과에서 제외하고, 동적 추천 사유(`recommendReason`) 및 태그(`tags`) 필드 생성

## 변경 내용

### Repository
- `BookmarkRepository`: 사용자의 찜한 시설 ID 목록 조회 쿼리 추가
- `VisitHistoryRepository`: 사용자의 방문 시설 ID 목록 조회 쿼리 추가

### Elasticsearch 스코어링 (FacilitySearchCustomRepositoryImpl)
| # | 스코어링 요소 | 조건 | 가중치 |
|---|---|---|---|
| 1 | 평점 가중치 | `field_value_factor(avgRating)` | `factor=1.2, log1p` |
| 2 | 자치구 친밀도 | 사용자 거주 자치구 일치 | `weight: 3.0` |
| 3 | 서비스 유형 선호도 | 찜한 시설과 동일 serviceType | `weight: 2.0` |
| 4 | 무료 시설 가산점 | `isFree=true` | `weight: 1.5` |
| 5 | 거리 감쇠 | `exp decay(location, 3km)` | `decay: 0.5` |

- 방문 시설 `must_not` ids 필터 추가
- `scoreMode: sum`, `boostMode: replace`

### Service (FacilityService)
- 찜 목록에서 선호 서비스 유형 추출
- 방문 기록에서 제외 대상 시설 수집
- 위치 미제공 시 사용자 등록 주소(`addressLat/Lng`) 기본값 사용
- 동적 추천 사유 및 태그 생성 로직 구현

### Response DTO (FacilityRecommendResponse)
- `List<String> tags` 필드 추가 (예: `["우리동네", "무료", "인기"]`)

## Test plan
- [x] `FacilityServiceTest` 수정 및 통과 확인
- [x] `FacilityControllerTest` 수정 및 통과 확인
- [x] `FacilitySearchRepositoryIntegrationTest` 시그니처 변경 반영
- [ ] Swagger UI에서 `/api/v1/facilities/recommend?childId=1` 호출 시 `tags` 포함 + `recommendReason` 동적 변경 확인