### PR TITLE
fix: PR #45 Copilot 리뷰 반영

### DIFF
--- a/src/main/java/com/aidom/api/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/aidom/api/domain/bookmark/repository/BookmarkRepository.java
@@ -2,6 +2,7 @@ package com.aidom.api.domain.bookmark.repository;
 
 import com.aidom.api.domain.bookmark.entity.Bookmark;
 import com.aidom.api.domain.bookmark.enums.BookmarkStatus;
+import com.aidom.api.domain.facility.enums.ServiceType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +27,13 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
   boolean existsByUserIdAndFacilityIdAndStatus(
       Long userId, String facilityId, BookmarkStatus status);
 
-  @Query("SELECT b.facility.id FROM Bookmark b WHERE b.user.id = :userId AND b.status = 'ACTIVE'")
-  List<String> findFacilityIdsByUserId(@Param("userId") Long userId);
+  @Query("SELECT b.facility.id FROM Bookmark b WHERE b.user.id = :userId AND b.status = :status")
+  List<String> findFacilityIdsByUserId(
+      @Param("userId") Long userId, @Param("status") BookmarkStatus status);
+
+  @Query(
+      "SELECT DISTINCT f.serviceType FROM Bookmark b JOIN b.facility f"
+          + " WHERE b.user.id = :userId AND b.status = :status")
+  List<ServiceType> findDistinctServiceTypesByUserId(
+      @Param("userId") Long userId, @Param("status") BookmarkStatus status);
 }

--- a/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
@@ -1,5 +1,6 @@
 package com.aidom.api.domain.facility.service;
 
+import com.aidom.api.domain.bookmark.enums.BookmarkStatus;
 import com.aidom.api.domain.bookmark.repository.BookmarkRepository;
 import com.aidom.api.domain.facility.document.FacilityDocument;
 import com.aidom.api.domain.facility.dto.FacilityDetailResponse;
@@ -16,6 +17,7 @@ import com.aidom.api.domain.facility.repository.FacilitySearchRepository;
 import com.aidom.api.domain.user.entity.Child;
 import com.aidom.api.domain.user.entity.User;
 import com.aidom.api.domain.user.service.ChildService;
+import com.aidom.api.domain.visit.enums.VisitStatus;
 import com.aidom.api.domain.visit.repository.VisitHistoryRepository;
 import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
@@ -102,20 +104,17 @@ public class FacilityService {
     User user = child.getUser();
     int childAge = calculateAge(child.getBirthDate());
 
-    // 찜한 시설 ID 및 서비스 유형 조회
-    List<String> bookmarkedFacilityIds = bookmarkRepository.findFacilityIdsByUserId(user.getId());
-    Set<String> preferredServiceTypes;
-    if (!bookmarkedFacilityIds.isEmpty()) {
-      preferredServiceTypes =
-          facilityRepository.findAllById(bookmarkedFacilityIds).stream()
-              .map(f -> f.getServiceType().getDescription())
-              .collect(Collectors.toSet());
-    } else {
-      preferredServiceTypes = Set.of();
-    }
+    // 찜한 시설의 서비스 유형 조회
+    Set<String> preferredServiceTypes =
+        bookmarkRepository
+            .findDistinctServiceTypesByUserId(user.getId(), BookmarkStatus.ACTIVE)
+            .stream()
+            .map(ServiceType::getDescription)
+            .collect(Collectors.toSet());
 
     // 방문한 시설 ID 조회 (제외 대상)
-    List<String> visitedFacilityIds = visitHistoryRepository.findFacilityIdsByUserId(user.getId());
+    List<String> visitedFacilityIds =
+        visitHistoryRepository.findFacilityIdsByUserId(user.getId(), VisitStatus.CANCELLED);
     Set<String> excludeFacilityIds = new HashSet<>(visitedFacilityIds);
 
     // 위치 미제공 시 사용자 주소 기본값 사용

--- a/src/main/java/com/aidom/api/domain/visit/repository/VisitHistoryRepository.java
+++ b/src/main/java/com/aidom/api/domain/visit/repository/VisitHistoryRepository.java
@@ -65,6 +65,7 @@ public interface VisitHistoryRepository extends JpaRepository<VisitHistory, Long
 
   @Query(
       "SELECT DISTINCT v.facility.id FROM VisitHistory v"
-          + " WHERE v.user.id = :userId AND v.status <> 'CANCELLED'")
-  List<String> findFacilityIdsByUserId(@Param("userId") Long userId);
+          + " WHERE v.user.id = :userId AND v.status <> :excludedStatus")
+  List<String> findFacilityIdsByUserId(
+      @Param("userId") Long userId, @Param("excludedStatus") VisitStatus excludedStatus);
 }

--- a/src/main/java/com/aidom/api/domain/visit/service/VisitService.java
+++ b/src/main/java/com/aidom/api/domain/visit/service/VisitService.java
@@ -85,6 +85,12 @@ public class VisitService {
             .findById(request.facilityId())
             .orElseThrow(() -> new CustomException(ErrorCode.FACILITY_NOT_FOUND));
 
+    if (request.startTime() != null
+        && request.endTime() != null
+        && request.endTime().isBefore(request.startTime())) {
+      throw new CustomException(ErrorCode.INVALID_VISIT_TIME_RANGE);
+    }
+
     VisitHistory visitHistory =
         VisitHistory.builder()
             .user(user)

--- a/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
@@ -144,8 +144,8 @@ class FacilityServiceTest {
             .gender(Gender.MALE)
             .build();
     given(childService.getChildById(1L)).willReturn(child);
-    given(bookmarkRepository.findFacilityIdsByUserId(any())).willReturn(List.of());
-    given(visitHistoryRepository.findFacilityIdsByUserId(any())).willReturn(List.of());
+    given(bookmarkRepository.findDistinctServiceTypesByUserId(any(), any())).willReturn(List.of());
+    given(visitHistoryRepository.findFacilityIdsByUserId(any(), any())).willReturn(List.of());
 
     FacilityDocument doc = createDocument("FAC001", "강남 키움센터");
     given(
@@ -157,7 +157,9 @@ class FacilityServiceTest {
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).id()).isEqualTo("FAC001");
-    assertThat(result.get(0).tags()).isNotNull();
+    // 픽스처: districtName=강남구(userDistrict와 동일), isFree=true, avgRating=4.5
+    assertThat(result.get(0).recommendReason()).contains("우리 동네(강남구)");
+    assertThat(result.get(0).tags()).containsExactly("우리동네", "무료", "인기");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- PR #45 AI 추천 시스템 개인화 고도화에 대한 Copilot 코드 리뷰 피드백 반영

## 변경 내용
- **JPQL enum 문자열 리터럴 제거**: `BookmarkRepository`, `VisitHistoryRepository`에서 `'ACTIVE'`, `'CANCELLED'` 문자열 리터럴을 `@Param` 바인딩으로 변경하여 enum 리팩터링/오타에 안전하게 처리
- **전체 엔티티 로딩 최적화**: `facilityRepository.findAllById()`로 Facility 전체를 로딩하던 방식 대신, `BookmarkRepository.findDistinctServiceTypesByUserId()` 전용 JPQL 쿼리로 serviceType만 조회하도록 개선
- **테스트 검증 보강**: `recommendFacilities_mapsResult` 테스트에서 `tags`가 null이 아닌지만 확인하던 것을 `recommendReason` 문구 및 `tags` 구체 값(`["우리동네", "무료", "인기"]`)까지 검증하도록 강화
- **createVisit 시간 범위 검증**: `endTime`이 `startTime`보다 이른 경우 `INVALID_VISIT_TIME_RANGE` 예외를 발생시키도록 검증 추가

## Test plan
- [x] `FacilityServiceTest` 통과 확인
- [x] `FacilityControllerTest` 통과 확인
- [x] `spotlessCheck` 통과 확인