### PR TITLE
fix: Copilot 리뷰 P2 — bookmarkCount 버그 수정 및 Claude API hot path 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/java/com/aidom/api/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/aidom/api/domain/bookmark/repository/BookmarkRepository.java
@@ -27,6 +27,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
   boolean existsByUserIdAndFacilityIdAndStatus(
       Long userId, String facilityId, BookmarkStatus status);
 
+  long countByUserIdAndStatus(Long userId, BookmarkStatus status);
+
   @Query("SELECT b.facility.id FROM Bookmark b WHERE b.user.id = :userId AND b.status = :status")
   List<String> findFacilityIdsByUserId(
       @Param("userId") Long userId, @Param("status") BookmarkStatus status);

--- a/src/main/java/com/aidom/api/domain/facility/dto/ScoringWeights.java
+++ b/src/main/java/com/aidom/api/domain/facility/dto/ScoringWeights.java
@@ -1,0 +1,24 @@
+package com.aidom.api.domain.facility.dto;
+
+public record ScoringWeights(
+    double ratingFactor,
+    double districtMatchWeight,
+    double serviceTypeWeight,
+    double freeWeight,
+    double distanceDecay) {
+
+  public static final ScoringWeights DEFAULT = new ScoringWeights(1.2, 3.0, 2.0, 1.5, 0.5);
+
+  public boolean isValid() {
+    return ratingFactor >= 0.1
+        && ratingFactor <= 5.0
+        && districtMatchWeight >= 0.0
+        && districtMatchWeight <= 10.0
+        && serviceTypeWeight >= 0.0
+        && serviceTypeWeight <= 10.0
+        && freeWeight >= 0.0
+        && freeWeight <= 10.0
+        && distanceDecay >= 0.1
+        && distanceDecay <= 1.0;
+  }
+}

--- a/src/main/java/com/aidom/api/domain/facility/dto/UserRecommendationContext.java
+++ b/src/main/java/com/aidom/api/domain/facility/dto/UserRecommendationContext.java
@@ -1,0 +1,13 @@
+package com.aidom.api.domain.facility.dto;
+
+import java.util.Set;
+
+public record UserRecommendationContext(
+    int childAge,
+    String district,
+    int bookmarkCount,
+    Set<String> preferredServiceTypes,
+    int visitCount,
+    boolean locationProvided,
+    String timeOfDay,
+    String season) {}

--- a/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepository.java
+++ b/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepository.java
@@ -1,6 +1,7 @@
 package com.aidom.api.domain.facility.repository;
 
 import com.aidom.api.domain.facility.document.FacilityDocument;
+import com.aidom.api.domain.facility.dto.ScoringWeights;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
@@ -34,6 +35,16 @@ public interface FacilitySearchCustomRepository {
       Set<String> preferredServiceTypes,
       String userDistrict,
       int limit);
+
+  List<FacilityDocument> recommendByChildAge(
+      int childAge,
+      Double lat,
+      Double lng,
+      Set<String> excludeFacilityIds,
+      Set<String> preferredServiceTypes,
+      String userDistrict,
+      int limit,
+      ScoringWeights weights);
 
   List<String> getDistinctDistrictNames();
 }

--- a/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepositoryImpl.java
+++ b/src/main/java/com/aidom/api/domain/facility/repository/FacilitySearchCustomRepositoryImpl.java
@@ -6,6 +6,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.FunctionBoostMode;
 import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreMode;
 import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
 import com.aidom.api.domain.facility.document.FacilityDocument;
+import com.aidom.api.domain.facility.dto.ScoringWeights;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -166,6 +167,27 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
       Set<String> preferredServiceTypes,
       String userDistrict,
       int limit) {
+    return recommendByChildAge(
+        childAge,
+        lat,
+        lng,
+        excludeFacilityIds,
+        preferredServiceTypes,
+        userDistrict,
+        limit,
+        ScoringWeights.DEFAULT);
+  }
+
+  @Override
+  public List<FacilityDocument> recommendByChildAge(
+      int childAge,
+      Double lat,
+      Double lng,
+      Set<String> excludeFacilityIds,
+      Set<String> preferredServiceTypes,
+      String userDistrict,
+      int limit,
+      ScoringWeights weights) {
 
     NativeQuery query =
         NativeQuery.builder()
@@ -207,19 +229,19 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
                                         return b;
                                       }));
 
-                          // 1. 평점 가중치 (기존)
+                          // 1. 평점 가중치
                           fs.functions(
                               fn ->
                                   fn.fieldValueFactor(
                                       fvf ->
                                           fvf.field("avgRating")
-                                              .factor(1.2)
+                                              .factor(weights.ratingFactor())
                                               .modifier(
                                                   co.elastic.clients.elasticsearch._types.query_dsl
                                                       .FieldValueFactorModifier.Log1p)
                                               .missing(0.0)));
 
-                          // 2. 자치구 친밀도 (신규)
+                          // 2. 자치구 친밀도
                           if (userDistrict != null && !userDistrict.isBlank()) {
                             fs.functions(
                                 fn ->
@@ -229,10 +251,10 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
                                                     t ->
                                                         t.field("districtName")
                                                             .value(userDistrict)))
-                                        .weight(3.0));
+                                        .weight(weights.districtMatchWeight()));
                           }
 
-                          // 3. 서비스 유형 선호도 (신규)
+                          // 3. 서비스 유형 선호도
                           if (preferredServiceTypes != null && !preferredServiceTypes.isEmpty()) {
                             fs.functions(
                                 fn ->
@@ -253,16 +275,16 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
                                                                                         .FieldValue
                                                                                     ::of)
                                                                             .toList()))))
-                                        .weight(2.0));
+                                        .weight(weights.serviceTypeWeight()));
                           }
 
-                          // 4. 무료 시설 가산점 (신규)
+                          // 4. 무료 시설 가산점
                           fs.functions(
                               fn ->
                                   fn.filter(f -> f.term(t -> t.field("isFree").value(true)))
-                                      .weight(1.5));
+                                      .weight(weights.freeWeight()));
 
-                          // 5. 거리 감쇠 (기존)
+                          // 5. 거리 감쇠
                           if (lat != null && lng != null) {
                             fs.functions(
                                 fn ->
@@ -285,7 +307,9 @@ public class FacilitySearchCustomRepositoryImpl implements FacilitySearchCustomR
                                                                                                 lng))))
                                                                     .scale("3km")
                                                                     .offset("0km")
-                                                                    .decay(0.5)))));
+                                                                    .decay(
+                                                                        weights
+                                                                            .distanceDecay())))));
                           }
 
                           fs.scoreMode(FunctionScoreMode.Sum);

--- a/src/main/java/com/aidom/api/domain/facility/service/ClaudeWeightClient.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/ClaudeWeightClient.java
@@ -5,6 +5,13 @@ import com.aidom.api.domain.facility.dto.UserRecommendationContext;
 import com.aidom.api.global.config.ClaudeProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
@@ -39,13 +46,27 @@ public class ClaudeWeightClient {
   private final RestClient restClient;
   private final ClaudeProperties properties;
   private final ObjectMapper objectMapper;
+  private final Cache<UserRecommendationContext, ScoringWeights> weightCache;
+  private final Executor executor;
+  private final Set<UserRecommendationContext> pendingContexts = ConcurrentHashMap.newKeySet();
 
   public ClaudeWeightClient(
       RestClient.Builder restClientBuilder,
       ClaudeProperties properties,
       ObjectMapper objectMapper) {
+    this(restClientBuilder, properties, objectMapper, ForkJoinPool.commonPool());
+  }
+
+  ClaudeWeightClient(
+      RestClient.Builder restClientBuilder,
+      ClaudeProperties properties,
+      ObjectMapper objectMapper,
+      Executor executor) {
     this.properties = properties;
     this.objectMapper = objectMapper;
+    this.executor = executor;
+    this.weightCache =
+        Caffeine.newBuilder().maximumSize(200).expireAfterWrite(30, TimeUnit.MINUTES).build();
 
     SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
     requestFactory.setConnectTimeout(properties.getConnectTimeout());
@@ -60,7 +81,32 @@ public class ClaudeWeightClient {
       return ScoringWeights.DEFAULT;
     }
 
+    ScoringWeights cached = weightCache.getIfPresent(context);
+    if (cached != null) {
+      log.debug("Returning cached weights for context: {}", context);
+      return cached;
+    }
+
+    if (pendingContexts.add(context)) {
+      executor.execute(() -> fetchAndCacheWeights(context));
+    }
+    return ScoringWeights.DEFAULT;
+  }
+
+  private void fetchAndCacheWeights(UserRecommendationContext context) {
     try {
+      ScoringWeights result = callClaudeApi(context);
+      if (!result.equals(ScoringWeights.DEFAULT)) {
+        weightCache.put(context, result);
+      }
+    } finally {
+      pendingContexts.remove(context);
+    }
+  }
+
+  private ScoringWeights callClaudeApi(UserRecommendationContext context) {
+    try {
+      String apiKey = properties.getApiKey();
       String userMessage = objectMapper.writeValueAsString(context);
 
       String requestBody =

--- a/src/main/java/com/aidom/api/domain/facility/service/ClaudeWeightClient.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/ClaudeWeightClient.java
@@ -3,6 +3,7 @@ package com.aidom.api.domain.facility.service;
 import com.aidom.api.domain.facility.dto.ScoringWeights;
 import com.aidom.api.domain.facility.dto.UserRecommendationContext;
 import com.aidom.api.global.config.ClaudeProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
@@ -167,7 +168,8 @@ public class ClaudeWeightClient {
     }
   }
 
-  private record ClaudeRequest(String model, int max_tokens, String system, Message[] messages) {}
+  private record ClaudeRequest(
+      String model, @JsonProperty("max_tokens") int maxTokens, String system, Message[] messages) {}
 
   private record Message(String role, String content) {}
 }

--- a/src/main/java/com/aidom/api/domain/facility/service/ClaudeWeightClient.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/ClaudeWeightClient.java
@@ -51,6 +51,7 @@ public class ClaudeWeightClient {
   private final Executor executor;
   private final Set<UserRecommendationContext> pendingContexts = ConcurrentHashMap.newKeySet();
 
+  @org.springframework.beans.factory.annotation.Autowired
   public ClaudeWeightClient(
       RestClient.Builder restClientBuilder,
       ClaudeProperties properties,

--- a/src/main/java/com/aidom/api/domain/facility/service/ClaudeWeightClient.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/ClaudeWeightClient.java
@@ -1,0 +1,127 @@
+package com.aidom.api.domain.facility.service;
+
+import com.aidom.api.domain.facility.dto.ScoringWeights;
+import com.aidom.api.domain.facility.dto.UserRecommendationContext;
+import com.aidom.api.global.config.ClaudeProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "app.claude.enabled", havingValue = "true")
+public class ClaudeWeightClient {
+
+  private static final String ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+  private static final String ANTHROPIC_VERSION = "2023-06-01";
+
+  private static final String SYSTEM_PROMPT =
+      """
+      You are a scoring weight calculator for a childcare facility recommendation system.
+      Given user context, return JSON: {"ratingFactor":N,"districtMatchWeight":N,"serviceTypeWeight":N,"freeWeight":N,"distanceDecay":N}
+      Rules:
+      - ratingFactor: 0.1~5.0
+      - districtMatchWeight: 0.0~10.0
+      - serviceTypeWeight: 0.0~10.0
+      - freeWeight: 0.0~10.0
+      - distanceDecay: 0.1~1.0
+      - More bookmarks -> stronger serviceTypeWeight
+      - Young children (0-3) -> higher freeWeight
+      - Has district -> boost districtMatchWeight
+      - No location -> distanceDecay = 0.5
+      - Respond ONLY with JSON, no explanation""";
+
+  private final RestClient restClient;
+  private final ClaudeProperties properties;
+  private final ObjectMapper objectMapper;
+
+  public ClaudeWeightClient(
+      RestClient.Builder restClientBuilder,
+      ClaudeProperties properties,
+      ObjectMapper objectMapper) {
+    this.properties = properties;
+    this.objectMapper = objectMapper;
+
+    SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+    requestFactory.setConnectTimeout(properties.getConnectTimeout());
+    requestFactory.setReadTimeout(properties.getReadTimeout());
+    this.restClient = restClientBuilder.requestFactory(requestFactory).build();
+  }
+
+  public ScoringWeights calculateWeights(UserRecommendationContext context) {
+    String apiKey = properties.getApiKey();
+    if (apiKey == null || apiKey.isBlank()) {
+      log.debug("Claude API key not configured, using default weights");
+      return ScoringWeights.DEFAULT;
+    }
+
+    try {
+      String userMessage = objectMapper.writeValueAsString(context);
+
+      String requestBody =
+          objectMapper.writeValueAsString(
+              new ClaudeRequest(
+                  properties.getModel(),
+                  256,
+                  SYSTEM_PROMPT,
+                  new Message[] {new Message("user", userMessage)}));
+
+      String responseBody =
+          restClient
+              .post()
+              .uri(ANTHROPIC_API_URL)
+              .contentType(MediaType.APPLICATION_JSON)
+              .header("x-api-key", apiKey.trim())
+              .header("anthropic-version", ANTHROPIC_VERSION)
+              .body(requestBody)
+              .retrieve()
+              .body(String.class);
+
+      return parseResponse(responseBody);
+    } catch (Exception e) {
+      log.warn("Claude API call failed, using default weights: {}", e.getMessage());
+      return ScoringWeights.DEFAULT;
+    }
+  }
+
+  private ScoringWeights parseResponse(String responseBody) {
+    try {
+      JsonNode root = objectMapper.readTree(responseBody);
+      JsonNode content = root.path("content");
+      if (!content.isArray() || content.isEmpty()) {
+        log.warn("Claude response has no content, using default weights");
+        return ScoringWeights.DEFAULT;
+      }
+
+      String text = content.get(0).path("text").asText();
+      JsonNode weights = objectMapper.readTree(text);
+
+      ScoringWeights result =
+          new ScoringWeights(
+              weights.path("ratingFactor").asDouble(),
+              weights.path("districtMatchWeight").asDouble(),
+              weights.path("serviceTypeWeight").asDouble(),
+              weights.path("freeWeight").asDouble(),
+              weights.path("distanceDecay").asDouble());
+
+      if (!result.isValid()) {
+        log.warn("Claude returned out-of-range weights, using default weights: {}", text);
+        return ScoringWeights.DEFAULT;
+      }
+
+      return result;
+    } catch (Exception e) {
+      log.warn("Failed to parse Claude response, using default weights: {}", e.getMessage());
+      return ScoringWeights.DEFAULT;
+    }
+  }
+
+  private record ClaudeRequest(String model, int max_tokens, String system, Message[] messages) {}
+
+  private record Message(String role, String content) {}
+}

--- a/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
@@ -31,10 +31,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -42,6 +42,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 @ConditionalOnProperty(
     name = "spring.data.elasticsearch.repositories.enabled",
@@ -54,23 +55,7 @@ public class FacilityService {
   private final ChildService childService;
   private final BookmarkRepository bookmarkRepository;
   private final VisitHistoryRepository visitHistoryRepository;
-  private final Optional<ClaudeWeightClient> claudeWeightClient;
-
-  @Autowired
-  public FacilityService(
-      FacilitySearchRepository facilitySearchRepository,
-      FacilityRepository facilityRepository,
-      ChildService childService,
-      BookmarkRepository bookmarkRepository,
-      VisitHistoryRepository visitHistoryRepository,
-      @Autowired(required = false) ClaudeWeightClient claudeWeightClient) {
-    this.facilitySearchRepository = facilitySearchRepository;
-    this.facilityRepository = facilityRepository;
-    this.childService = childService;
-    this.bookmarkRepository = bookmarkRepository;
-    this.visitHistoryRepository = visitHistoryRepository;
-    this.claudeWeightClient = Optional.ofNullable(claudeWeightClient);
-  }
+  private final ObjectProvider<ClaudeWeightClient> claudeWeightClient;
 
   public Page<FacilityListResponse> listFacilities(
       String districtName,
@@ -157,17 +142,16 @@ public class FacilityService {
         new UserRecommendationContext(
             childAge,
             userDistrict,
-            (int) bookmarkCount,
+            Math.toIntExact(bookmarkCount),
             preferredServiceTypes,
             visitedFacilityIds.size(),
             latVal != null && lngVal != null,
             resolveTimeOfDay(),
             resolveSeason());
 
+    ClaudeWeightClient weightClient = claudeWeightClient.getIfAvailable();
     ScoringWeights weights =
-        claudeWeightClient
-            .map(client -> client.calculateWeights(context))
-            .orElse(ScoringWeights.DEFAULT);
+        weightClient != null ? weightClient.calculateWeights(context) : ScoringWeights.DEFAULT;
 
     List<FacilityDocument> docs =
         facilitySearchRepository.recommendByChildAge(

--- a/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/aidom/api/domain/facility/service/FacilityService.java
@@ -8,6 +8,8 @@ import com.aidom.api.domain.facility.dto.FacilityFilterResponse;
 import com.aidom.api.domain.facility.dto.FacilityListResponse;
 import com.aidom.api.domain.facility.dto.FacilityRecommendResponse;
 import com.aidom.api.domain.facility.dto.FacilitySearchResponse;
+import com.aidom.api.domain.facility.dto.ScoringWeights;
+import com.aidom.api.domain.facility.dto.UserRecommendationContext;
 import com.aidom.api.domain.facility.entity.Facility;
 import com.aidom.api.domain.facility.entity.FacilityExternalInfo;
 import com.aidom.api.domain.facility.entity.FacilityStats;
@@ -23,14 +25,16 @@ import com.aidom.api.global.error.CustomException;
 import com.aidom.api.global.error.ErrorCode;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,7 +42,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 @ConditionalOnProperty(
     name = "spring.data.elasticsearch.repositories.enabled",
@@ -51,6 +54,23 @@ public class FacilityService {
   private final ChildService childService;
   private final BookmarkRepository bookmarkRepository;
   private final VisitHistoryRepository visitHistoryRepository;
+  private final Optional<ClaudeWeightClient> claudeWeightClient;
+
+  @Autowired
+  public FacilityService(
+      FacilitySearchRepository facilitySearchRepository,
+      FacilityRepository facilityRepository,
+      ChildService childService,
+      BookmarkRepository bookmarkRepository,
+      VisitHistoryRepository visitHistoryRepository,
+      @Autowired(required = false) ClaudeWeightClient claudeWeightClient) {
+    this.facilitySearchRepository = facilitySearchRepository;
+    this.facilityRepository = facilityRepository;
+    this.childService = childService;
+    this.bookmarkRepository = bookmarkRepository;
+    this.visitHistoryRepository = visitHistoryRepository;
+    this.claudeWeightClient = Optional.ofNullable(claudeWeightClient);
+  }
 
   public Page<FacilityListResponse> listFacilities(
       String districtName,
@@ -112,6 +132,9 @@ public class FacilityService {
             .map(ServiceType::getDescription)
             .collect(Collectors.toSet());
 
+    long bookmarkCount =
+        bookmarkRepository.countByUserIdAndStatus(user.getId(), BookmarkStatus.ACTIVE);
+
     // 방문한 시설 ID 조회 (제외 대상)
     List<String> visitedFacilityIds =
         visitHistoryRepository.findFacilityIdsByUserId(user.getId(), VisitStatus.CANCELLED);
@@ -129,6 +152,23 @@ public class FacilityService {
 
     String userDistrict = user.getDistrict();
 
+    // LLM 기반 가중치 동적 계산
+    UserRecommendationContext context =
+        new UserRecommendationContext(
+            childAge,
+            userDistrict,
+            (int) bookmarkCount,
+            preferredServiceTypes,
+            visitedFacilityIds.size(),
+            latVal != null && lngVal != null,
+            resolveTimeOfDay(),
+            resolveSeason());
+
+    ScoringWeights weights =
+        claudeWeightClient
+            .map(client -> client.calculateWeights(context))
+            .orElse(ScoringWeights.DEFAULT);
+
     List<FacilityDocument> docs =
         facilitySearchRepository.recommendByChildAge(
             childAge,
@@ -137,7 +177,8 @@ public class FacilityService {
             excludeFacilityIds,
             preferredServiceTypes,
             userDistrict,
-            limit);
+            limit,
+            weights);
 
     return docs.stream()
         .map(doc -> toRecommendResponse(doc, childAge, userDistrict, preferredServiceTypes))
@@ -188,6 +229,21 @@ public class FacilityService {
 
   private int calculateAge(LocalDate birthDate) {
     return (int) ChronoUnit.YEARS.between(birthDate, LocalDate.now());
+  }
+
+  private String resolveTimeOfDay() {
+    int hour = LocalTime.now().getHour();
+    if (hour < 12) return "morning";
+    if (hour < 18) return "afternoon";
+    return "evening";
+  }
+
+  private String resolveSeason() {
+    int month = LocalDate.now().getMonthValue();
+    if (month >= 3 && month <= 5) return "spring";
+    if (month >= 6 && month <= 8) return "summer";
+    if (month >= 9 && month <= 11) return "autumn";
+    return "winter";
   }
 
   private FacilityListResponse toListResponse(FacilityDocument doc) {

--- a/src/main/java/com/aidom/api/domain/test/LocalTestAccountCatalog.java
+++ b/src/main/java/com/aidom/api/domain/test/LocalTestAccountCatalog.java
@@ -1,0 +1,103 @@
+package com.aidom.api.domain.test;
+
+import com.aidom.api.domain.user.enums.ParentRelation;
+import com.aidom.api.domain.user.enums.Provider;
+import com.aidom.api.domain.user.enums.Role;
+import com.aidom.api.domain.user.enums.UserStatus;
+import com.aidom.api.global.common.entity.Gender;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+final class LocalTestAccountCatalog {
+
+  static final List<LocalTestAccount> ACCOUNTS =
+      List.of(
+          new LocalTestAccount(
+              900001L,
+              "local-parent-1-access-token",
+              "local-parent-1-refresh-token",
+              "김민서",
+              "minseo.local@aidom.test",
+              Provider.KAKAO,
+              "local-kakao-900001",
+              Role.USER,
+              UserStatus.ACTIVE,
+              ParentRelation.MOTHER,
+              LocalDate.of(1991, 5, 12),
+              "010-9000-0001",
+              "서울특별시 강남구 테헤란로 212",
+              "서울특별시",
+              "강남구",
+              "101동 1203호",
+              new BigDecimal("37.4980950"),
+              new BigDecimal("127.0276100"),
+              List.of(
+                  new LocalTestChild(
+                      910001L, "김하윤", LocalDate.of(2018, 3, 14), Gender.FEMALE, "미술 프로그램 선호", true),
+                  new LocalTestChild(
+                      910002L,
+                      "김도윤",
+                      LocalDate.of(2015, 9, 2),
+                      Gender.MALE,
+                      "방과 후 돌봄 테스트용",
+                      false))),
+          new LocalTestAccount(
+              900002L,
+              "local-parent-2-access-token",
+              "local-parent-2-refresh-token",
+              "박준호",
+              "junho.local@aidom.test",
+              Provider.GOOGLE,
+              "local-google-900002",
+              Role.USER,
+              UserStatus.ACTIVE,
+              ParentRelation.FATHER,
+              LocalDate.of(1988, 11, 21),
+              "010-9000-0002",
+              "서울특별시 송파구 올림픽로 300",
+              "서울특별시",
+              "송파구",
+              "테스트 보호자 주소",
+              new BigDecimal("37.5132612"),
+              new BigDecimal("127.1028670"),
+              List.of(
+                  new LocalTestChild(
+                      910003L,
+                      "박서윤",
+                      LocalDate.of(2019, 7, 8),
+                      Gender.FEMALE,
+                      "주말 체험형 프로그램 테스트용",
+                      true))));
+
+  private LocalTestAccountCatalog() {}
+
+  record LocalTestAccount(
+      Long userId,
+      String accessToken,
+      String refreshToken,
+      String name,
+      String email,
+      Provider provider,
+      String providerId,
+      Role role,
+      UserStatus status,
+      ParentRelation relation,
+      LocalDate birthDate,
+      String phone,
+      String address,
+      String city,
+      String district,
+      String addressDetail,
+      BigDecimal addressLat,
+      BigDecimal addressLng,
+      List<LocalTestChild> children) {}
+
+  record LocalTestChild(
+      Long childId,
+      String name,
+      LocalDate birthDate,
+      Gender gender,
+      String specialNote,
+      boolean primary) {}
+}

--- a/src/main/java/com/aidom/api/domain/test/LocalTestAccountController.java
+++ b/src/main/java/com/aidom/api/domain/test/LocalTestAccountController.java
@@ -1,0 +1,94 @@
+package com.aidom.api.domain.test;
+
+import static com.aidom.api.domain.test.LocalTestAccountCatalog.ACCOUNTS;
+
+import com.aidom.api.domain.test.LocalTestAccountCatalog.LocalTestAccount;
+import com.aidom.api.domain.test.LocalTestAccountCatalog.LocalTestChild;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("local")
+@RestController
+@RequestMapping("/api/test/accounts")
+public class LocalTestAccountController {
+
+  @GetMapping
+  public ResponseEntity<LocalTestAccountsResponse> getLocalTestAccounts() {
+    return ResponseEntity.ok(
+        new LocalTestAccountsResponse(
+            "현재 백엔드는 로그인 토큰을 검증하지 않습니다. 아래 토큰은 프론트/수동 API 테스트용 고정 mock 값입니다.",
+            ACCOUNTS.stream().map(this::toAccountResponse).toList()));
+  }
+
+  private LocalTestAccountResponse toAccountResponse(LocalTestAccount account) {
+    return new LocalTestAccountResponse(
+        account.userId(),
+        account.name(),
+        account.email(),
+        account.provider().name(),
+        account.providerId(),
+        account.role().name(),
+        account.status().name(),
+        account.relation().name(),
+        account.birthDate(),
+        account.phone(),
+        account.address(),
+        account.city(),
+        account.district(),
+        account.addressDetail(),
+        account.addressLat(),
+        account.addressLng(),
+        account.accessToken(),
+        account.refreshToken(),
+        "Bearer " + account.accessToken(),
+        account.children().stream().map(this::toChildResponse).toList());
+  }
+
+  private LocalTestChildResponse toChildResponse(LocalTestChild child) {
+    return new LocalTestChildResponse(
+        child.childId(),
+        child.name(),
+        child.birthDate(),
+        child.gender().name(),
+        child.specialNote(),
+        child.primary());
+  }
+
+  public record LocalTestAccountsResponse(String note, List<LocalTestAccountResponse> accounts) {}
+
+  public record LocalTestAccountResponse(
+      Long userId,
+      String name,
+      String email,
+      String provider,
+      String providerId,
+      String role,
+      String status,
+      String relation,
+      LocalDate birthDate,
+      String phone,
+      String address,
+      String city,
+      String district,
+      String addressDetail,
+      BigDecimal addressLat,
+      BigDecimal addressLng,
+      String accessToken,
+      String refreshToken,
+      String authorizationHeader,
+      List<LocalTestChildResponse> children) {}
+
+  public record LocalTestChildResponse(
+      Long childId,
+      String name,
+      LocalDate birthDate,
+      String gender,
+      String specialNote,
+      boolean primary) {}
+}

--- a/src/main/java/com/aidom/api/domain/test/LocalTestAccountController.java
+++ b/src/main/java/com/aidom/api/domain/test/LocalTestAccountController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile("local")
+@Profile({"local", "test"})
 @RestController
 @RequestMapping("/api/test/accounts")
 public class LocalTestAccountController {
@@ -22,7 +22,7 @@ public class LocalTestAccountController {
   public ResponseEntity<LocalTestAccountsResponse> getLocalTestAccounts() {
     return ResponseEntity.ok(
         new LocalTestAccountsResponse(
-            "현재 백엔드는 로그인 토큰을 검증하지 않습니다. 아래 토큰은 프론트/수동 API 테스트용 고정 mock 값입니다.",
+            "로컬/테스트 환경 전용 고정 mock 계정입니다. 실제 JWT 토큰이 아니므로 인증이 필요한 API에는 사용할 수 없습니다.",
             ACCOUNTS.stream().map(this::toAccountResponse).toList()));
   }
 

--- a/src/main/java/com/aidom/api/domain/test/LocalTestAccountSeeder.java
+++ b/src/main/java/com/aidom/api/domain/test/LocalTestAccountSeeder.java
@@ -1,0 +1,183 @@
+package com.aidom.api.domain.test;
+
+import static com.aidom.api.domain.test.LocalTestAccountCatalog.ACCOUNTS;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile("local")
+@Component
+@RequiredArgsConstructor
+class LocalTestAccountSeeder implements ApplicationRunner {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  @Override
+  @Transactional
+  public void run(ApplicationArguments args) {
+    LocalDateTime now = LocalDateTime.now();
+
+    for (LocalTestAccountCatalog.LocalTestAccount account : ACCOUNTS) {
+      upsertUser(account, now);
+
+      for (LocalTestAccountCatalog.LocalTestChild child : account.children()) {
+        upsertChild(account.userId(), child, now);
+      }
+    }
+  }
+
+  private void upsertUser(LocalTestAccountCatalog.LocalTestAccount account, LocalDateTime now) {
+    if (exists("users", "user_id", account.userId())) {
+      jdbcTemplate.update(
+          """
+          update users
+             set updated_at = ?,
+                 name = ?,
+                 email = ?,
+                 provider = ?,
+                 provider_id = ?,
+                 role = ?,
+                 status = ?,
+                 relation = ?,
+                 birth_date = ?,
+                 phone = ?,
+                 address = ?,
+                 city = ?,
+                 district = ?,
+                 address_detail = ?,
+                 address_lat = ?,
+                 address_lng = ?,
+                 deleted_at = null
+           where user_id = ?
+          """,
+          Timestamp.valueOf(now),
+          account.name(),
+          account.email(),
+          account.provider().name(),
+          account.providerId(),
+          account.role().name(),
+          account.status().name(),
+          account.relation().name(),
+          account.birthDate(),
+          account.phone(),
+          account.address(),
+          account.city(),
+          account.district(),
+          account.addressDetail(),
+          account.addressLat(),
+          account.addressLng(),
+          account.userId());
+      return;
+    }
+
+    jdbcTemplate.update(
+        """
+        insert into users (
+            user_id,
+            created_at,
+            updated_at,
+            name,
+            email,
+            provider,
+            provider_id,
+            role,
+            status,
+            relation,
+            birth_date,
+            phone,
+            address,
+            city,
+            district,
+            address_detail,
+            address_lat,
+            address_lng,
+            deleted_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null)
+        """,
+        account.userId(),
+        Timestamp.valueOf(now),
+        Timestamp.valueOf(now),
+        account.name(),
+        account.email(),
+        account.provider().name(),
+        account.providerId(),
+        account.role().name(),
+        account.status().name(),
+        account.relation().name(),
+        account.birthDate(),
+        account.phone(),
+        account.address(),
+        account.city(),
+        account.district(),
+        account.addressDetail(),
+        account.addressLat(),
+        account.addressLng());
+  }
+
+  private void upsertChild(
+      Long userId, LocalTestAccountCatalog.LocalTestChild child, LocalDateTime now) {
+    if (exists("children", "child_id", child.childId())) {
+      jdbcTemplate.update(
+          """
+          update children
+             set updated_at = ?,
+                 user_id = ?,
+                 name = ?,
+                 birth_date = ?,
+                 gender = ?,
+                 special_note = ?,
+                 is_primary = ?,
+                 deleted_at = null
+           where child_id = ?
+          """,
+          Timestamp.valueOf(now),
+          userId,
+          child.name(),
+          child.birthDate(),
+          child.gender().name(),
+          child.specialNote(),
+          child.primary(),
+          child.childId());
+      return;
+    }
+
+    jdbcTemplate.update(
+        """
+        insert into children (
+            child_id,
+            created_at,
+            updated_at,
+            user_id,
+            name,
+            birth_date,
+            gender,
+            special_note,
+            is_primary,
+            deleted_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, null)
+        """,
+        child.childId(),
+        Timestamp.valueOf(now),
+        Timestamp.valueOf(now),
+        userId,
+        child.name(),
+        child.birthDate(),
+        child.gender().name(),
+        child.specialNote(),
+        child.primary());
+  }
+
+  private boolean exists(String tableName, String idColumn, Long id) {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            "select count(*) from " + tableName + " where " + idColumn + " = ?", Integer.class, id);
+    return count != null && count > 0;
+  }
+}

--- a/src/main/java/com/aidom/api/domain/test/LocalTestAccountSeeder.java
+++ b/src/main/java/com/aidom/api/domain/test/LocalTestAccountSeeder.java
@@ -12,7 +12,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-@Profile("local")
+@Profile({"local", "test"})
 @Component
 @RequiredArgsConstructor
 class LocalTestAccountSeeder implements ApplicationRunner {

--- a/src/main/java/com/aidom/api/domain/test/LocalTestAccountSeeder.java
+++ b/src/main/java/com/aidom/api/domain/test/LocalTestAccountSeeder.java
@@ -99,7 +99,7 @@ class LocalTestAccountSeeder implements ApplicationRunner {
             address_lat,
             address_lng,
             deleted_at
-        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null)
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null)
         """,
         account.userId(),
         Timestamp.valueOf(now),

--- a/src/main/java/com/aidom/api/domain/test/bootstrap/TestAccountBootstrapProperties.java
+++ b/src/main/java/com/aidom/api/domain/test/bootstrap/TestAccountBootstrapProperties.java
@@ -1,0 +1,96 @@
+package com.aidom.api.domain.test.bootstrap;
+
+import com.aidom.api.domain.user.enums.ParentRelation;
+import com.aidom.api.domain.user.enums.Provider;
+import com.aidom.api.domain.user.enums.Role;
+import com.aidom.api.domain.user.enums.UserStatus;
+import com.aidom.api.global.common.entity.Gender;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Component
+@Validated
+@ConfigurationProperties(prefix = "app.ops.test-account")
+public class TestAccountBootstrapProperties {
+
+  private boolean enabled = false;
+
+  @NotBlank private String requestId = "manual-bootstrap";
+
+  @NotBlank private String email = "ops-test-parent@aidom.test";
+
+  @NotBlank private String name = "운영 테스트 보호자";
+
+  @NotNull private Provider provider = Provider.KAKAO;
+
+  @NotBlank private String providerId = "ops-kakao-test-parent";
+
+  @NotNull private Role role = Role.USER;
+
+  @NotNull private UserStatus status = UserStatus.ACTIVE;
+
+  @NotNull private ParentRelation relation = ParentRelation.MOTHER;
+
+  @NotNull private LocalDate birthDate = LocalDate.of(1990, 1, 1);
+
+  @NotBlank private String phone = "010-5555-0001";
+
+  @NotBlank private String address = "서울특별시 강남구 테헤란로 212";
+
+  @NotBlank private String city = "서울특별시";
+
+  @NotBlank private String district = "강남구";
+
+  private String addressDetail = "운영 테스트 계정";
+
+  @NotNull private BigDecimal addressLat = new BigDecimal("37.4980950");
+
+  @NotNull private BigDecimal addressLng = new BigDecimal("127.0276100");
+
+  private boolean logRefreshToken = false;
+
+  @Valid
+  @Size(min = 1, max = 5)
+  private List<ChildSpec> children =
+      new ArrayList<>(
+          List.of(
+              new ChildSpec(
+                  "테스트아동1", LocalDate.of(2018, 3, 14), Gender.FEMALE, "운영 추천/방문 테스트용", true),
+              new ChildSpec(
+                  "테스트아동2", LocalDate.of(2015, 9, 2), Gender.MALE, "운영 북마크/이용내역 테스트용", false)));
+
+  @Getter
+  @Setter
+  public static class ChildSpec {
+
+    @NotBlank private String name;
+    @NotNull private LocalDate birthDate;
+    @NotNull private Gender gender;
+    private String specialNote;
+    private boolean primary;
+
+    public ChildSpec() {}
+
+    public ChildSpec(
+        String name, LocalDate birthDate, Gender gender, String specialNote, boolean primary) {
+      this.name = name;
+      this.birthDate = birthDate;
+      this.gender = gender;
+      this.specialNote = specialNote;
+      this.primary = primary;
+    }
+  }
+}

--- a/src/main/java/com/aidom/api/domain/test/bootstrap/TestAccountBootstrapProperties.java
+++ b/src/main/java/com/aidom/api/domain/test/bootstrap/TestAccountBootstrapProperties.java
@@ -60,6 +60,8 @@ public class TestAccountBootstrapProperties {
 
   @NotNull private BigDecimal addressLng = new BigDecimal("127.0276100");
 
+  private boolean logAccessToken = false;
+
   private boolean logRefreshToken = false;
 
   @Valid

--- a/src/main/java/com/aidom/api/domain/test/bootstrap/TestAccountBootstrapRunner.java
+++ b/src/main/java/com/aidom/api/domain/test/bootstrap/TestAccountBootstrapRunner.java
@@ -1,0 +1,174 @@
+package com.aidom.api.domain.test.bootstrap;
+
+import com.aidom.api.domain.auth.entity.RefreshToken;
+import com.aidom.api.domain.auth.repository.RefreshTokenRepository;
+import com.aidom.api.domain.test.bootstrap.TestAccountBootstrapProperties.ChildSpec;
+import com.aidom.api.domain.user.entity.Child;
+import com.aidom.api.domain.user.entity.ProvisionedProfile;
+import com.aidom.api.domain.user.entity.User;
+import com.aidom.api.domain.user.repository.UserRepository;
+import com.aidom.api.global.config.AppAuthProperties;
+import com.aidom.api.global.security.JwtTokenProvider;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.ops.test-account", name = "enabled", havingValue = "true")
+public class TestAccountBootstrapRunner implements ApplicationRunner {
+
+  private final TestAccountBootstrapProperties properties;
+  private final UserRepository userRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final AppAuthProperties authProperties;
+  private final Clock clock;
+
+  @Override
+  @Transactional
+  public void run(ApplicationArguments args) {
+    User user = upsertUser();
+
+    String accessToken = jwtTokenProvider.createAccessToken(user);
+    String refreshToken = jwtTokenProvider.createRefreshToken(user);
+
+    refreshTokenRepository.save(
+        RefreshToken.builder()
+            .user(user)
+            .tokenHash(hash(refreshToken))
+            .expiresAt(now().plus(authProperties.getJwt().getRefreshTokenValidity()))
+            .build());
+
+    logBootstrapResult(user, accessToken, refreshToken);
+  }
+
+  private User upsertUser() {
+    User user =
+        userRepository
+            .findByEmailIncludingDeleted(properties.getEmail())
+            .orElseGet(
+                () ->
+                    User.builder()
+                        .email(properties.getEmail())
+                        .name(properties.getName())
+                        .provider(properties.getProvider())
+                        .providerId(properties.getProviderId())
+                        .role(properties.getRole())
+                        .status(properties.getStatus())
+                        .build());
+
+    user.applyProvisionedProfile(
+        ProvisionedProfile.builder()
+            .name(properties.getName())
+            .email(properties.getEmail())
+            .provider(properties.getProvider())
+            .providerId(properties.getProviderId())
+            .role(properties.getRole())
+            .status(properties.getStatus())
+            .relation(properties.getRelation())
+            .birthDate(properties.getBirthDate())
+            .phone(properties.getPhone())
+            .address(properties.getAddress())
+            .city(properties.getCity())
+            .district(properties.getDistrict())
+            .addressDetail(properties.getAddressDetail())
+            .addressLat(properties.getAddressLat())
+            .addressLng(properties.getAddressLng())
+            .build());
+
+    user.clearChildren();
+    for (ChildSpec childSpec : normalizedChildren(properties.getChildren())) {
+      user.addChild(
+          Child.of(
+              childSpec.getName(),
+              childSpec.getBirthDate(),
+              childSpec.getGender(),
+              childSpec.getSpecialNote(),
+              childSpec.isPrimary()));
+    }
+
+    return userRepository.saveAndFlush(user);
+  }
+
+  private List<ChildSpec> normalizedChildren(List<ChildSpec> children) {
+    boolean hasPrimary = children.stream().anyMatch(ChildSpec::isPrimary);
+
+    if (hasPrimary) {
+      return children;
+    }
+
+    return children.stream()
+        .map(
+            child ->
+                new ChildSpec(
+                    child.getName(),
+                    child.getBirthDate(),
+                    child.getGender(),
+                    child.getSpecialNote(),
+                    false))
+        .collect(Collectors.collectingAndThen(Collectors.toList(), list -> setPrimary(list)));
+  }
+
+  private List<ChildSpec> setPrimary(List<ChildSpec> children) {
+    if (!children.isEmpty()) {
+      children.get(0).setPrimary(true);
+    }
+    return children;
+  }
+
+  private void logBootstrapResult(User user, String accessToken, String refreshToken) {
+    String childSummary =
+        user.getChildren().stream()
+            .map(
+                child ->
+                    child.getId() + ":" + child.getName() + "(primary=" + child.isPrimary() + ")")
+            .collect(Collectors.joining(", "));
+
+    log.warn("============================================================");
+    log.warn("PRODUCTION TEST ACCOUNT BOOTSTRAP COMPLETED");
+    log.warn("requestId={}", properties.getRequestId());
+    log.warn(
+        "userId={}, email={}, provider={}, providerId={}, status={}",
+        user.getId(),
+        user.getEmail(),
+        user.getProvider(),
+        user.getProviderId(),
+        user.getStatus());
+    log.warn("childIds={}", childSummary);
+    log.warn("accessToken={}", accessToken);
+    log.warn("authorizationHeader=Bearer {}", accessToken);
+    log.warn("accessTokenExpiresInSeconds={}", jwtTokenProvider.getAccessTokenExpiresInSeconds());
+    if (properties.isLogRefreshToken()) {
+      log.warn("refreshToken={}", refreshToken);
+    }
+    log.warn("Disable APP_OPS_TEST_ACCOUNT_ENABLED after collecting the token.");
+    log.warn("============================================================");
+  }
+
+  private String hash(String raw) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] bytes = digest.digest(raw.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(bytes);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to hash token", e);
+    }
+  }
+
+  private LocalDateTime now() {
+    return LocalDateTime.now(clock);
+  }
+}

--- a/src/main/java/com/aidom/api/domain/test/bootstrap/TestAccountBootstrapRunner.java
+++ b/src/main/java/com/aidom/api/domain/test/bootstrap/TestAccountBootstrapRunner.java
@@ -148,8 +148,15 @@ public class TestAccountBootstrapRunner implements ApplicationRunner {
         user.getProviderId(),
         user.getStatus());
     log.warn("childIds={}", childSummary);
-    log.warn("accessToken={}", accessToken);
-    log.warn("authorizationHeader=Bearer {}", accessToken);
+    if (properties.isLogAccessToken()) {
+      log.warn("accessToken={}", accessToken);
+      log.warn("authorizationHeader=Bearer {}", accessToken);
+    } else {
+      log.warn(
+          "accessToken={}...{}",
+          accessToken.substring(0, Math.min(8, accessToken.length())),
+          "(masked)");
+    }
     log.warn("accessTokenExpiresInSeconds={}", jwtTokenProvider.getAccessTokenExpiresInSeconds());
     if (properties.isLogRefreshToken()) {
       log.warn("refreshToken={}", refreshToken);

--- a/src/main/java/com/aidom/api/global/config/ClaudeConfig.java
+++ b/src/main/java/com/aidom/api/global/config/ClaudeConfig.java
@@ -1,0 +1,8 @@
+package com.aidom.api.global.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ClaudeProperties.class)
+public class ClaudeConfig {}

--- a/src/main/java/com/aidom/api/global/config/ClaudeProperties.java
+++ b/src/main/java/com/aidom/api/global/config/ClaudeProperties.java
@@ -1,0 +1,18 @@
+package com.aidom.api.global.config;
+
+import java.time.Duration;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "app.claude")
+public class ClaudeProperties {
+
+  private String apiKey;
+  private String model = "claude-haiku-4-20250414";
+  private Duration connectTimeout = Duration.ofSeconds(1);
+  private Duration readTimeout = Duration.ofSeconds(3);
+  private boolean enabled = true;
+}

--- a/src/main/resources/application-integration-test.properties
+++ b/src/main/resources/application-integration-test.properties
@@ -16,3 +16,6 @@ app.auth.jwt.auth-code-validity=60s
 
 # Elasticsearch
 spring.data.elasticsearch.repositories.enabled=true
+
+# Claude API disabled for integration tests
+app.claude.enabled=false

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -22,3 +22,6 @@ spring.autoconfigure.exclude=\
   org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration,\
   org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration
 spring.data.elasticsearch.repositories.enabled=false
+
+# Claude API disabled for tests
+app.claude.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,10 @@ app.auth.kakao.admin-key=${KAKAO_ADMIN_KEY:}
 app.auth.kakao.unlink-uri=https://kapi.kakao.com/v1/user/unlink
 app.auth.kakao.connect-timeout=2s
 app.auth.kakao.read-timeout=5s
+
+# Claude API (LLM-based recommendation weights)
+app.claude.api-key=${CLAUDE_API_KEY:}
+app.claude.model=claude-haiku-4-20250414
+app.claude.connect-timeout=1s
+app.claude.read-timeout=3s
+app.claude.enabled=true

--- a/src/test/java/com/aidom/api/domain/facility/dto/ScoringWeightsTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/dto/ScoringWeightsTest.java
@@ -1,0 +1,50 @@
+package com.aidom.api.domain.facility.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ScoringWeightsTest {
+
+  @Test
+  @DisplayName("DEFAULT 상수가 valid이다")
+  void defaultIsValid() {
+    assertThat(ScoringWeights.DEFAULT.isValid()).isTrue();
+  }
+
+  @Test
+  @DisplayName("모든 필드가 경계 최솟값이면 valid이다")
+  void validBoundaryValues() {
+    ScoringWeights weights = new ScoringWeights(0.1, 0.0, 0.0, 0.0, 0.1);
+    assertThat(weights.isValid()).isTrue();
+  }
+
+  @Test
+  @DisplayName("ratingFactor가 0.0이면 invalid이다")
+  void ratingFactorTooLow_invalid() {
+    ScoringWeights weights = new ScoringWeights(0.0, 0.0, 0.0, 0.0, 0.1);
+    assertThat(weights.isValid()).isFalse();
+  }
+
+  @Test
+  @DisplayName("ratingFactor가 5.1이면 invalid이다")
+  void ratingFactorTooHigh_invalid() {
+    ScoringWeights weights = new ScoringWeights(5.1, 0.0, 0.0, 0.0, 0.1);
+    assertThat(weights.isValid()).isFalse();
+  }
+
+  @Test
+  @DisplayName("distanceDecay가 1.1이면 invalid이다")
+  void distanceDecayTooHigh_invalid() {
+    ScoringWeights weights = new ScoringWeights(0.1, 0.0, 0.0, 0.0, 1.1);
+    assertThat(weights.isValid()).isFalse();
+  }
+
+  @Test
+  @DisplayName("모든 필드가 경계 최댓값이면 valid이다")
+  void allMaxBoundary_valid() {
+    ScoringWeights weights = new ScoringWeights(5.0, 10.0, 10.0, 10.0, 1.0);
+    assertThat(weights.isValid()).isTrue();
+  }
+}

--- a/src/test/java/com/aidom/api/domain/facility/service/ClaudeWeightClientTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/service/ClaudeWeightClientTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.aidom.api.domain.facility.dto.ScoringWeights;
@@ -43,7 +44,7 @@ class ClaudeWeightClientTest {
     given(restClientBuilder.requestFactory(any())).willReturn(restClientBuilder);
     given(restClientBuilder.build()).willReturn(restClient);
 
-    client = new ClaudeWeightClient(restClientBuilder, properties, objectMapper);
+    client = new ClaudeWeightClient(restClientBuilder, properties, objectMapper, Runnable::run);
   }
 
   @Test
@@ -69,7 +70,7 @@ class ClaudeWeightClientTest {
   }
 
   @Test
-  @DisplayName("정상 Claude JSON 응답이면 파싱된 커스텀 가중치를 반환한다")
+  @DisplayName("정상 Claude JSON 응답이면 비동기 fetch 후 캐시되어 다음 호출에서 파싱된 가중치를 반환한다")
   void validResponse_returnsParsedWeights() {
     properties.setApiKey("test-api-key");
     String response =
@@ -78,13 +79,19 @@ class ClaudeWeightClientTest {
                 + "\"serviceTypeWeight\":4.0,\"freeWeight\":3.0,\"distanceDecay\":0.8}");
     stubApiCall(response);
 
-    ScoringWeights result = client.calculateWeights(createContext());
+    UserRecommendationContext context = createContext();
 
-    assertThat(result.ratingFactor()).isEqualTo(2.0);
-    assertThat(result.districtMatchWeight()).isEqualTo(5.0);
-    assertThat(result.serviceTypeWeight()).isEqualTo(4.0);
-    assertThat(result.freeWeight()).isEqualTo(3.0);
-    assertThat(result.distanceDecay()).isEqualTo(0.8);
+    // 1차: cache miss → 비동기 fetch → DEFAULT 반환
+    ScoringWeights first = client.calculateWeights(context);
+    assertThat(first).isEqualTo(ScoringWeights.DEFAULT);
+
+    // 2차: cache hit → 파싱된 가중치 반환
+    ScoringWeights second = client.calculateWeights(context);
+    assertThat(second.ratingFactor()).isEqualTo(2.0);
+    assertThat(second.districtMatchWeight()).isEqualTo(5.0);
+    assertThat(second.serviceTypeWeight()).isEqualTo(4.0);
+    assertThat(second.freeWeight()).isEqualTo(3.0);
+    assertThat(second.distanceDecay()).isEqualTo(0.8);
   }
 
   @Test
@@ -144,6 +151,68 @@ class ClaudeWeightClientTest {
     ScoringWeights result = client.calculateWeights(createContext());
 
     assertThat(result).isEqualTo(ScoringWeights.DEFAULT);
+  }
+
+  @Test
+  @DisplayName("동일 context로 반복 호출하면 API는 한 번만 호출되고 캐시된 결과를 반환한다")
+  void cachedResult_returnsWithoutApiCall() {
+    properties.setApiKey("test-api-key");
+    String response =
+        claudeResponse(
+            "{\"ratingFactor\":2.0,\"districtMatchWeight\":5.0,"
+                + "\"serviceTypeWeight\":4.0,\"freeWeight\":3.0,\"distanceDecay\":0.8}");
+    stubApiCall(response);
+
+    UserRecommendationContext context = createContext();
+
+    // 1차: cache miss → 비동기 fetch → DEFAULT
+    client.calculateWeights(context);
+
+    // 2차, 3차: cache hit → API 추가 호출 없이 캐시 반환
+    ScoringWeights second = client.calculateWeights(context);
+    ScoringWeights third = client.calculateWeights(context);
+
+    assertThat(second).isEqualTo(third);
+    assertThat(second.ratingFactor()).isEqualTo(2.0);
+    verify(restClient, times(1)).post();
+  }
+
+  @Test
+  @DisplayName("DEFAULT 결과는 캐시되지 않아 다음 호출에서 커스텀 가중치를 반환할 수 있다")
+  void defaultResult_isNotCached() {
+    properties.setApiKey("test-api-key");
+
+    String response =
+        claudeResponse(
+            "{\"ratingFactor\":2.0,\"districtMatchWeight\":5.0,"
+                + "\"serviceTypeWeight\":4.0,\"freeWeight\":3.0,\"distanceDecay\":0.8}");
+
+    // retrieve()를 연속 스텁: 1차 예외, 2차 정상
+    given(restClient.post()).willReturn(requestBodyUriSpec);
+    given(requestBodyUriSpec.uri(anyString())).willReturn(requestBodySpec);
+    given(requestBodySpec.contentType(any(MediaType.class))).willReturn(requestBodySpec);
+    given(requestBodySpec.header(anyString(), any(String[].class))).willReturn(requestBodySpec);
+    given(requestBodySpec.body((Object) any())).willReturn(requestBodySpec);
+    given(requestBodySpec.retrieve())
+        .willThrow(new RestClientException("Connection refused"))
+        .willReturn(responseSpec);
+    given(responseSpec.body(String.class)).willReturn(response);
+
+    UserRecommendationContext context = createContext();
+
+    // 1차: 비동기 fetch 실패 → DEFAULT, 캐시 안 됨
+    ScoringWeights first = client.calculateWeights(context);
+    assertThat(first).isEqualTo(ScoringWeights.DEFAULT);
+
+    // 2차: 비동기 fetch 성공 → DEFAULT 반환, 캐시 적재
+    ScoringWeights second = client.calculateWeights(context);
+    assertThat(second).isEqualTo(ScoringWeights.DEFAULT);
+
+    // 3차: cache hit → 커스텀 가중치
+    ScoringWeights third = client.calculateWeights(context);
+    assertThat(third.ratingFactor()).isEqualTo(2.0);
+    assertThat(third).isNotEqualTo(ScoringWeights.DEFAULT);
+    verify(restClient, times(2)).post();
   }
 
   private void stubApiCall(String responseBody) {

--- a/src/test/java/com/aidom/api/domain/facility/service/ClaudeWeightClientTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/service/ClaudeWeightClientTest.java
@@ -1,0 +1,177 @@
+package com.aidom.api.domain.facility.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.aidom.api.domain.facility.dto.ScoringWeights;
+import com.aidom.api.domain.facility.dto.UserRecommendationContext;
+import com.aidom.api.global.config.ClaudeProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@ExtendWith(MockitoExtension.class)
+class ClaudeWeightClientTest {
+
+  @Mock private RestClient.Builder restClientBuilder;
+  @Mock private RestClient restClient;
+  @Mock private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+  @Mock private RestClient.RequestBodySpec requestBodySpec;
+  @Mock private RestClient.ResponseSpec responseSpec;
+
+  private ClaudeProperties properties;
+  private ObjectMapper objectMapper;
+  private ClaudeWeightClient client;
+
+  @BeforeEach
+  void setUp() {
+    properties = new ClaudeProperties();
+    objectMapper = new ObjectMapper();
+
+    given(restClientBuilder.requestFactory(any())).willReturn(restClientBuilder);
+    given(restClientBuilder.build()).willReturn(restClient);
+
+    client = new ClaudeWeightClient(restClientBuilder, properties, objectMapper);
+  }
+
+  @Test
+  @DisplayName("apiKey가 빈 문자열이면 DEFAULT를 반환하고 RestClient를 호출하지 않는다")
+  void apiKeyBlank_returnsDefault() {
+    properties.setApiKey("");
+
+    ScoringWeights result = client.calculateWeights(createContext());
+
+    assertThat(result).isEqualTo(ScoringWeights.DEFAULT);
+    verify(restClient, never()).post();
+  }
+
+  @Test
+  @DisplayName("apiKey가 null이면 DEFAULT를 반환하고 RestClient를 호출하지 않는다")
+  void apiKeyNull_returnsDefault() {
+    properties.setApiKey(null);
+
+    ScoringWeights result = client.calculateWeights(createContext());
+
+    assertThat(result).isEqualTo(ScoringWeights.DEFAULT);
+    verify(restClient, never()).post();
+  }
+
+  @Test
+  @DisplayName("정상 Claude JSON 응답이면 파싱된 커스텀 가중치를 반환한다")
+  void validResponse_returnsParsedWeights() {
+    properties.setApiKey("test-api-key");
+    String response =
+        claudeResponse(
+            "{\"ratingFactor\":2.0,\"districtMatchWeight\":5.0,"
+                + "\"serviceTypeWeight\":4.0,\"freeWeight\":3.0,\"distanceDecay\":0.8}");
+    stubApiCall(response);
+
+    ScoringWeights result = client.calculateWeights(createContext());
+
+    assertThat(result.ratingFactor()).isEqualTo(2.0);
+    assertThat(result.districtMatchWeight()).isEqualTo(5.0);
+    assertThat(result.serviceTypeWeight()).isEqualTo(4.0);
+    assertThat(result.freeWeight()).isEqualTo(3.0);
+    assertThat(result.distanceDecay()).isEqualTo(0.8);
+  }
+
+  @Test
+  @DisplayName("범위 초과 가중치가 반환되면 DEFAULT를 반환한다")
+  void outOfRangeWeights_returnsDefault() {
+    properties.setApiKey("test-api-key");
+    String response =
+        claudeResponse(
+            "{\"ratingFactor\":99.0,\"districtMatchWeight\":5.0,"
+                + "\"serviceTypeWeight\":4.0,\"freeWeight\":3.0,\"distanceDecay\":0.8}");
+    stubApiCall(response);
+
+    ScoringWeights result = client.calculateWeights(createContext());
+
+    assertThat(result).isEqualTo(ScoringWeights.DEFAULT);
+  }
+
+  @Test
+  @DisplayName("content 배열이 비어있으면 DEFAULT를 반환한다")
+  void emptyContentArray_returnsDefault() {
+    properties.setApiKey("test-api-key");
+    stubApiCall("{\"content\":[]}");
+
+    ScoringWeights result = client.calculateWeights(createContext());
+
+    assertThat(result).isEqualTo(ScoringWeights.DEFAULT);
+  }
+
+  @Test
+  @DisplayName("content.text가 유효하지 않은 JSON이면 DEFAULT를 반환한다")
+  void malformedJson_returnsDefault() {
+    properties.setApiKey("test-api-key");
+    stubApiCall(claudeResponse("not-a-json"));
+
+    ScoringWeights result = client.calculateWeights(createContext());
+
+    assertThat(result).isEqualTo(ScoringWeights.DEFAULT);
+  }
+
+  @Test
+  @DisplayName("RestClient가 예외를 던지면 DEFAULT를 반환한다")
+  void restClientException_returnsDefault() {
+    properties.setApiKey("test-api-key");
+    stubApiCallException(new RestClientException("Connection refused"));
+
+    ScoringWeights result = client.calculateWeights(createContext());
+
+    assertThat(result).isEqualTo(ScoringWeights.DEFAULT);
+  }
+
+  @Test
+  @DisplayName("RestClient가 null body를 반환하면 DEFAULT를 반환한다")
+  void nullResponseBody_returnsDefault() {
+    properties.setApiKey("test-api-key");
+    stubApiCall(null);
+
+    ScoringWeights result = client.calculateWeights(createContext());
+
+    assertThat(result).isEqualTo(ScoringWeights.DEFAULT);
+  }
+
+  private void stubApiCall(String responseBody) {
+    given(restClient.post()).willReturn(requestBodyUriSpec);
+    given(requestBodyUriSpec.uri(anyString())).willReturn(requestBodySpec);
+    given(requestBodySpec.contentType(any(MediaType.class))).willReturn(requestBodySpec);
+    given(requestBodySpec.header(anyString(), any(String[].class))).willReturn(requestBodySpec);
+    given(requestBodySpec.body((Object) any())).willReturn(requestBodySpec);
+    given(requestBodySpec.retrieve()).willReturn(responseSpec);
+    given(responseSpec.body(String.class)).willReturn(responseBody);
+  }
+
+  private void stubApiCallException(RuntimeException ex) {
+    given(restClient.post()).willReturn(requestBodyUriSpec);
+    given(requestBodyUriSpec.uri(anyString())).willReturn(requestBodySpec);
+    given(requestBodySpec.contentType(any(MediaType.class))).willReturn(requestBodySpec);
+    given(requestBodySpec.header(anyString(), any(String[].class))).willReturn(requestBodySpec);
+    given(requestBodySpec.body((Object) any())).willReturn(requestBodySpec);
+    given(requestBodySpec.retrieve()).willThrow(ex);
+  }
+
+  private String claudeResponse(String textContent) {
+    String escaped = textContent.replace("\\", "\\\\").replace("\"", "\\\"");
+    return "{\"content\":[{\"type\":\"text\",\"text\":\"" + escaped + "\"}]}";
+  }
+
+  private UserRecommendationContext createContext() {
+    return new UserRecommendationContext(
+        5, "강남구", 3, Set.of("우리동네키움센터"), 2, true, "morning", "spring");
+  }
+}

--- a/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -56,6 +57,7 @@ class FacilityServiceTest {
   @Mock private BookmarkRepository bookmarkRepository;
   @Mock private VisitHistoryRepository visitHistoryRepository;
   @Mock private ClaudeWeightClient claudeWeightClient;
+  @Mock private ObjectProvider<ClaudeWeightClient> claudeWeightClientProvider;
 
   private FacilityService facilityService;
 
@@ -68,7 +70,7 @@ class FacilityServiceTest {
             childService,
             bookmarkRepository,
             visitHistoryRepository,
-            null);
+            claudeWeightClientProvider);
   }
 
   @Test
@@ -234,6 +236,7 @@ class FacilityServiceTest {
     ScoringWeights customWeights = new ScoringWeights(2.0, 5.0, 4.0, 3.0, 0.8);
     given(claudeWeightClient.calculateWeights(any(UserRecommendationContext.class)))
         .willReturn(customWeights);
+    given(claudeWeightClientProvider.getIfAvailable()).willReturn(claudeWeightClient);
 
     FacilityService serviceWithClaude =
         new FacilityService(
@@ -242,7 +245,7 @@ class FacilityServiceTest {
             childService,
             bookmarkRepository,
             visitHistoryRepository,
-            claudeWeightClient);
+            claudeWeightClientProvider);
 
     User user =
         User.builder()

--- a/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
+++ b/src/test/java/com/aidom/api/domain/facility/service/FacilityServiceTest.java
@@ -14,6 +14,8 @@ import com.aidom.api.domain.facility.dto.FacilityFilterResponse;
 import com.aidom.api.domain.facility.dto.FacilityListResponse;
 import com.aidom.api.domain.facility.dto.FacilityRecommendResponse;
 import com.aidom.api.domain.facility.dto.FacilitySearchResponse;
+import com.aidom.api.domain.facility.dto.ScoringWeights;
+import com.aidom.api.domain.facility.dto.UserRecommendationContext;
 import com.aidom.api.domain.facility.entity.Facility;
 import com.aidom.api.domain.facility.enums.ServiceType;
 import com.aidom.api.domain.facility.repository.FacilityRepository;
@@ -33,10 +35,10 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -53,8 +55,21 @@ class FacilityServiceTest {
   @Mock private ChildService childService;
   @Mock private BookmarkRepository bookmarkRepository;
   @Mock private VisitHistoryRepository visitHistoryRepository;
+  @Mock private ClaudeWeightClient claudeWeightClient;
 
-  @InjectMocks private FacilityService facilityService;
+  private FacilityService facilityService;
+
+  @BeforeEach
+  void setUp() {
+    facilityService =
+        new FacilityService(
+            facilitySearchRepository,
+            facilityRepository,
+            childService,
+            bookmarkRepository,
+            visitHistoryRepository,
+            null);
+  }
 
   @Test
   @DisplayName("키워드 검색 시 ES 결과를 FacilitySearchResponse로 매핑한다")
@@ -145,12 +160,20 @@ class FacilityServiceTest {
             .build();
     given(childService.getChildById(1L)).willReturn(child);
     given(bookmarkRepository.findDistinctServiceTypesByUserId(any(), any())).willReturn(List.of());
+    given(bookmarkRepository.countByUserIdAndStatus(any(), any())).willReturn(0L);
     given(visitHistoryRepository.findFacilityIdsByUserId(any(), any())).willReturn(List.of());
 
     FacilityDocument doc = createDocument("FAC001", "강남 키움센터");
     given(
             facilitySearchRepository.recommendByChildAge(
-                eq(7), isNull(), isNull(), any(Set.class), any(Set.class), eq("강남구"), eq(5)))
+                eq(7),
+                isNull(),
+                isNull(),
+                any(Set.class),
+                any(Set.class),
+                eq("강남구"),
+                eq(5),
+                eq(ScoringWeights.DEFAULT)))
         .willReturn(List.of(doc));
 
     List<FacilityRecommendResponse> result = facilityService.recommendFacilities(1L, null, null, 5);
@@ -203,6 +226,64 @@ class FacilityServiceTest {
     assertThat(result.districts()).hasSize(2);
     assertThat(result.ageRanges()).isNotEmpty();
     assertThat(result.careTypes()).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("ClaudeWeightClient가 커스텀 가중치를 반환하면 해당 가중치로 추천한다")
+  void recommendFacilities_withClaudeClient_usesCustomWeights() {
+    ScoringWeights customWeights = new ScoringWeights(2.0, 5.0, 4.0, 3.0, 0.8);
+    given(claudeWeightClient.calculateWeights(any(UserRecommendationContext.class)))
+        .willReturn(customWeights);
+
+    FacilityService serviceWithClaude =
+        new FacilityService(
+            facilitySearchRepository,
+            facilityRepository,
+            childService,
+            bookmarkRepository,
+            visitHistoryRepository,
+            claudeWeightClient);
+
+    User user =
+        User.builder()
+            .name("테스트유저")
+            .email("test@test.com")
+            .provider(Provider.KAKAO)
+            .providerId("12345")
+            .role(Role.USER)
+            .status(UserStatus.ACTIVE)
+            .district("강남구")
+            .build();
+    Child child =
+        Child.builder()
+            .user(user)
+            .name("테스트")
+            .birthDate(LocalDate.now().minusYears(5))
+            .gender(Gender.MALE)
+            .build();
+    given(childService.getChildById(1L)).willReturn(child);
+    given(bookmarkRepository.findDistinctServiceTypesByUserId(any(), any())).willReturn(List.of());
+    given(bookmarkRepository.countByUserIdAndStatus(any(), any())).willReturn(0L);
+    given(visitHistoryRepository.findFacilityIdsByUserId(any(), any())).willReturn(List.of());
+
+    FacilityDocument doc = createDocument("FAC001", "강남 키움센터");
+    given(
+            facilitySearchRepository.recommendByChildAge(
+                eq(5),
+                isNull(),
+                isNull(),
+                any(Set.class),
+                any(Set.class),
+                eq("강남구"),
+                eq(5),
+                eq(customWeights)))
+        .willReturn(List.of(doc));
+
+    List<FacilityRecommendResponse> result =
+        serviceWithClaude.recommendFacilities(1L, null, null, 5);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).id()).isEqualTo("FAC001");
   }
 
   private FacilityDocument createDocument(String id, String name) {

--- a/src/test/java/com/aidom/api/domain/test/bootstrap/TestAccountBootstrapRunnerTest.java
+++ b/src/test/java/com/aidom/api/domain/test/bootstrap/TestAccountBootstrapRunnerTest.java
@@ -1,0 +1,88 @@
+package com.aidom.api.domain.test.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aidom.api.domain.auth.entity.RefreshToken;
+import com.aidom.api.domain.auth.repository.RefreshTokenRepository;
+import com.aidom.api.domain.user.entity.User;
+import com.aidom.api.domain.user.enums.Provider;
+import com.aidom.api.domain.user.enums.Role;
+import com.aidom.api.domain.user.enums.UserStatus;
+import com.aidom.api.domain.user.repository.UserRepository;
+import com.aidom.api.global.config.AppAuthProperties;
+import com.aidom.api.global.security.JwtTokenProvider;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+class TestAccountBootstrapRunnerTest {
+
+  private static final Clock FIXED_CLOCK =
+      Clock.fixed(Instant.parse("2026-05-06T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+  @Mock private UserRepository userRepository;
+  @Mock private RefreshTokenRepository refreshTokenRepository;
+  @Mock private JwtTokenProvider jwtTokenProvider;
+
+  @Captor private ArgumentCaptor<User> userCaptor;
+  @Captor private ArgumentCaptor<RefreshToken> refreshTokenCaptor;
+
+  @Test
+  @DisplayName("활성화되면 테스트 부모/자녀를 저장하고 실제 토큰을 발급한다")
+  void run_bootstrapsUserChildrenAndRefreshToken() throws Exception {
+    TestAccountBootstrapProperties properties = new TestAccountBootstrapProperties();
+    AppAuthProperties authProperties = new AppAuthProperties();
+    authProperties.getJwt().setRefreshTokenValidity(Duration.ofDays(14));
+
+    when(userRepository.findByEmailIncludingDeleted(properties.getEmail()))
+        .thenReturn(Optional.empty());
+    when(userRepository.saveAndFlush(any(User.class)))
+        .thenAnswer(
+            invocation -> {
+              User saved = invocation.getArgument(0);
+              return saved;
+            });
+    when(jwtTokenProvider.createAccessToken(any(User.class))).thenReturn("access-token");
+    when(jwtTokenProvider.createRefreshToken(any(User.class))).thenReturn("refresh-token");
+
+    TestAccountBootstrapRunner runner =
+        new TestAccountBootstrapRunner(
+            properties,
+            userRepository,
+            refreshTokenRepository,
+            jwtTokenProvider,
+            authProperties,
+            FIXED_CLOCK);
+
+    runner.run(new DefaultApplicationArguments(new String[0]));
+
+    verify(userRepository).saveAndFlush(userCaptor.capture());
+    verify(refreshTokenRepository).save(refreshTokenCaptor.capture());
+
+    User savedUser = userCaptor.getValue();
+    assertThat(savedUser.getEmail()).isEqualTo(properties.getEmail());
+    assertThat(savedUser.getProvider()).isEqualTo(Provider.KAKAO);
+    assertThat(savedUser.getRole()).isEqualTo(Role.USER);
+    assertThat(savedUser.getStatus()).isEqualTo(UserStatus.ACTIVE);
+    assertThat(savedUser.getChildren()).hasSize(2);
+    assertThat(savedUser.getChildren().get(0).isPrimary()).isTrue();
+
+    RefreshToken refreshToken = refreshTokenCaptor.getValue();
+    assertThat(refreshToken.getUser()).isSameAs(savedUser);
+    assertThat(refreshToken.getTokenHash()).hasSize(64);
+  }
+}


### PR DESCRIPTION
## Summary

Copilot 리뷰에서 지적된 P2 이슈 2건 해결 및 코드 품질 개선을 반영합니다.

- **bookmarkCount 버그 수정**: `UserRecommendationContext.bookmarkCount`에 고유 서비스 유형 수(`preferredServiceTypes.size()`)가 들어가 Claude 가중치 계산이 왜곡되던 문제를 `BookmarkRepository.countByUserIdAndStatus()`로 교체하여 실제 북마크 수를 전달
- **Claude API hot path 제거**: 추천 API의 동기 경로에서 외부 LLM 호출을 제거하고, Caffeine 인메모리 캐시(TTL 30분, max 200)와 비동기 백그라운드 fetch로 전환하여 모든 요청이 즉시 응답
- **테스트 계정 인프라 개선**: `LocalTestAccountController`/`LocalTestAccountSeeder`의 `@Profile` 범위 확장, 응답 note 문구 정정, `TestAccountBootstrapRunner`의 accessToken 로그 기본 마스킹 처리
- **코드 스타일 정리**: `FacilityService` `Optional<T>` → `ObjectProvider<T>` + `@RequiredArgsConstructor`, `ClaudeRequest.max_tokens` → `maxTokens` + `@JsonProperty`, `(int)` 캐스트 → `Math.toIntExact`

## Changes

### Commit 1: `fix: bookmarkCount 버그 수정 및 Claude 가중치 동적 계산 연동`
| 파일 | 변경 |
|------|------|
| `BookmarkRepository` | `countByUserIdAndStatus` 카운트 쿼리 추가 |
| `FacilityService` | 실제 북마크 수 조회 + `UserRecommendationContext` 생성 |
| `FacilitySearchCustomRepository*` | `ScoringWeights` 파라미터 받는 오버로드 추가 |
| `ClaudeWeightClient` | Claude API 연동 클라이언트 (동기 버전) |
| `FacilityServiceTest` | `countByUserIdAndStatus` stub 추가 |

### Commit 2: `perf: Claude API 비동기 Caffeine 캐시 적용으로 hot path 제거`
| 파일 | 변경 |
|------|------|
| `build.gradle` | `caffeine` 의존성 추가 |
| `ClaudeWeightClient` | 캐시 + `Executor` 비동기 fetch + `pendingContexts` 중복 방지 |
| `ClaudeWeightClientTest` | 캐시 히트/미스, DEFAULT 미캐시 검증 테스트 추가 |

### Commit 3: `fix: Copilot 리뷰 반영 (코드 품질 개선)`
| 파일 | 변경 |
|------|------|
| `FacilityService` | `Optional` → `ObjectProvider` + `@RequiredArgsConstructor`, `Math.toIntExact` |
| `ClaudeWeightClient` | `max_tokens` → `maxTokens` + `@JsonProperty("max_tokens")` |
| `LocalTestAccountController` | `@Profile({"local", "test"})`, note 문구 정정 |
| `LocalTestAccountSeeder` | `@Profile({"local", "test"})` |
| `TestAccountBootstrapProperties` | `logAccessToken` 플래그 추가 |
| `TestAccountBootstrapRunner` | accessToken 로그 기본 마스킹 |
| `FacilityServiceTest` | `ObjectProvider` 모킹으로 변경 |

## Design decisions

- **DEFAULT는 캐시하지 않음**: API 장애로 인한 폴백 결과가 캐시되면 복구 후에도 TTL 동안 계속 폴백이 적용되므로, 성공 결과만 캐시
- **Cold-start 시 DEFAULT 사용**: 첫 요청은 기본 가중치로 응답하고, 백그라운드 fetch 완료 후 다음 요청부터 개인화 가중치 적용 — 지연 제거와 개인화 사이의 의도된 tradeoff
- **accessToken 로그 마스킹**: `logAccessToken` 기본 false, 운영 로그를 통한 토큰 유출 방지

## Test plan

- [x] `./gradlew test --tests '*ClaudeWeightClientTest'` — 10개 테스트 통과
- [x] `./gradlew test --tests '*ScoringWeightsTest'` — 통과
- [x] `./gradlew test --tests '*FacilityServiceTest'` — 통과
- [x] `./gradlew spotlessApply` — 포맷 검증 통과