### PR TITLE
fix: OAuth2 로그인 시 STATELESS 세션 정책으로 인한 403 수정

### DIFF
--- a/src/main/java/com/aidom/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/aidom/api/global/config/SecurityConfig.java
@@ -21,6 +21,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
 import org.springframework.web.cors.CorsConfiguration;
 
 @Configuration
@@ -53,7 +54,9 @@ public class SecurityConfig {
                       return config;
                     }))
         .sessionManagement(
-            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+        .securityContext(
+            sc -> sc.securityContextRepository(new RequestAttributeSecurityContextRepository()))
         .exceptionHandling(
             e ->
                 e.authenticationEntryPoint(authenticationEntryPoint)


### PR DESCRIPTION
## Summary

- OAuth2 로그인 콜백에서 403 ACCESS_DENIED 발생하던 문제 수정
- `SessionCreationPolicy.STATELESS`로 인해 OAuth2 authorization request의 state 파라미터를 세션에 저장/검증할 수 없었음

## Changes

- `SessionCreationPolicy.STATELESS` → `IF_REQUIRED`: OAuth2 흐름에서 세션 사용 허용
- `RequestAttributeSecurityContextRepository` 추가: SecurityContext가 세션에 저장되지 않아 JWT 기반 API 인증에 영향 없음

## Test plan

- [x] `./gradlew test --tests '*AidomBackendApplicationTests'` 통과
- [ ] 카카오 로그인 → 콜백 → 프론트 리다이렉트 확인