### PR TITLE
fix: OAuth2 로그인 쿠키 기반 state 관리로 전환

### DIFF
--- a/src/main/java/com/aidom/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/aidom/api/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.aidom.api.domain.auth.service.OAuth2AuthenticationSuccessHandler;
 import com.aidom.api.domain.user.enums.Role;
 import com.aidom.api.domain.user.enums.UserStatus;
 import com.aidom.api.global.security.AuthenticatedUserPrincipal;
+import com.aidom.api.global.security.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.aidom.api.global.security.JwtAuthenticationFilter;
 import com.aidom.api.global.security.ProblemDetailAccessDeniedHandler;
 import com.aidom.api.global.security.ProblemDetailAuthenticationEntryPoint;
@@ -21,7 +22,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
 import org.springframework.web.cors.CorsConfiguration;
 
 @Configuration
@@ -54,9 +54,7 @@ public class SecurityConfig {
                       return config;
                     }))
         .sessionManagement(
-            session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
-        .securityContext(
-            sc -> sc.securityContextRepository(new RequestAttributeSecurityContextRepository()))
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .exceptionHandling(
             e ->
                 e.authenticationEntryPoint(authenticationEntryPoint)
@@ -87,6 +85,10 @@ public class SecurityConfig {
       http.oauth2Login(
           oauth2 ->
               oauth2
+                  .authorizationEndpoint(
+                      a ->
+                          a.authorizationRequestRepository(
+                              new HttpCookieOAuth2AuthorizationRequestRepository()))
                   .userInfoEndpoint(endpoint -> endpoint.userService(customOAuth2UserService))
                   .successHandler(oAuth2AuthenticationSuccessHandler));
     }

--- a/src/main/java/com/aidom/api/global/security/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/aidom/api/global/security/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,85 @@
+package com.aidom.api.global.security;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+public class HttpCookieOAuth2AuthorizationRequestRepository
+    implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+  private static final String COOKIE_NAME = "oauth2_auth_request";
+  private static final int COOKIE_EXPIRE_SECONDS = 180;
+
+  @Override
+  public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+    return findCookie(request).map(Cookie::getValue).map(this::deserialize).orElse(null);
+  }
+
+  @Override
+  public void saveAuthorizationRequest(
+      OAuth2AuthorizationRequest authorizationRequest,
+      HttpServletRequest request,
+      HttpServletResponse response) {
+    if (authorizationRequest == null) {
+      deleteCookie(response);
+      return;
+    }
+    Cookie cookie = new Cookie(COOKIE_NAME, serialize(authorizationRequest));
+    cookie.setPath("/");
+    cookie.setHttpOnly(true);
+    cookie.setMaxAge(COOKIE_EXPIRE_SECONDS);
+    response.addCookie(cookie);
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest removeAuthorizationRequest(
+      HttpServletRequest request, HttpServletResponse response) {
+    OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+    deleteCookie(response);
+    return authorizationRequest;
+  }
+
+  private Optional<Cookie> findCookie(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return Optional.empty();
+    }
+    return Arrays.stream(cookies).filter(c -> COOKIE_NAME.equals(c.getName())).findFirst();
+  }
+
+  private void deleteCookie(HttpServletResponse response) {
+    Cookie cookie = new Cookie(COOKIE_NAME, "");
+    cookie.setPath("/");
+    cookie.setMaxAge(0);
+    response.addCookie(cookie);
+  }
+
+  private String serialize(OAuth2AuthorizationRequest request) {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(request);
+      return Base64.getUrlEncoder().encodeToString(bos.toByteArray());
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to serialize OAuth2AuthorizationRequest", e);
+    }
+  }
+
+  private OAuth2AuthorizationRequest deserialize(String value) {
+    try (ObjectInputStream ois =
+        new ObjectInputStream(new ByteArrayInputStream(Base64.getUrlDecoder().decode(value)))) {
+      return (OAuth2AuthorizationRequest) ois.readObject();
+    } catch (IOException | ClassNotFoundException e) {
+      throw new IllegalStateException("Failed to deserialize OAuth2AuthorizationRequest", e);
+    }
+  }
+}

--- a/src/main/java/com/aidom/api/global/security/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/aidom/api/global/security/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -11,9 +11,11 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
+@Slf4j
 public class HttpCookieOAuth2AuthorizationRequestRepository
     implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
@@ -31,12 +33,14 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
       HttpServletRequest request,
       HttpServletResponse response) {
     if (authorizationRequest == null) {
-      deleteCookie(response);
+      deleteCookie(request, response);
       return;
     }
     Cookie cookie = new Cookie(COOKIE_NAME, serialize(authorizationRequest));
     cookie.setPath("/");
     cookie.setHttpOnly(true);
+    cookie.setSecure(request.isSecure());
+    cookie.setAttribute("SameSite", "Lax");
     cookie.setMaxAge(COOKIE_EXPIRE_SECONDS);
     response.addCookie(cookie);
   }
@@ -45,7 +49,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
   public OAuth2AuthorizationRequest removeAuthorizationRequest(
       HttpServletRequest request, HttpServletResponse response) {
     OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
-    deleteCookie(response);
+    deleteCookie(request, response);
     return authorizationRequest;
   }
 
@@ -57,9 +61,11 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
     return Arrays.stream(cookies).filter(c -> COOKIE_NAME.equals(c.getName())).findFirst();
   }
 
-  private void deleteCookie(HttpServletResponse response) {
+  private void deleteCookie(HttpServletRequest request, HttpServletResponse response) {
     Cookie cookie = new Cookie(COOKIE_NAME, "");
     cookie.setPath("/");
+    cookie.setSecure(request.isSecure());
+    cookie.setAttribute("SameSite", "Lax");
     cookie.setMaxAge(0);
     response.addCookie(cookie);
   }
@@ -79,7 +85,8 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
         new ObjectInputStream(new ByteArrayInputStream(Base64.getUrlDecoder().decode(value)))) {
       return (OAuth2AuthorizationRequest) ois.readObject();
     } catch (IOException | ClassNotFoundException e) {
-      throw new IllegalStateException("Failed to deserialize OAuth2AuthorizationRequest", e);
+      log.warn("Failed to deserialize OAuth2AuthorizationRequest: {}", e.getMessage());
+      return null;
     }
   }
 }


### PR DESCRIPTION
## Summary

- `SessionCreationPolicy.STATELESS`에서 OAuth2 state를 세션에 저장할 수 없어 콜백 시 403 발생하던 문제 수정
- 세션 의존을 완전히 제거하고 쿠키 기반으로 전환

## Changes

- `HttpCookieOAuth2AuthorizationRequestRepository` 신규 — OAuth2AuthorizationRequest를 쿠키에 직렬화 (HttpOnly, TTL 3분)
- `SecurityConfig` — `STATELESS` 유지, 쿠키 기반 repo를 `authorizationEndpoint`에 등록
- PR #48의 `IF_REQUIRED` + `RequestAttributeSecurityContextRepository` 방식 대체

## Test plan

- [x] `./gradlew test --tests '*AidomBackendApplicationTests'` 통과
- [ ] 카카오 로그인 → 콜백 → code 발급 → 프론트 리다이렉트 확인