### PR TITLE
fix: OAuth2 로그인 실패 시 에러 메시지 리다이렉트 처리

### DIFF
--- a/src/main/java/com/aidom/api/domain/auth/service/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/aidom/api/domain/auth/service/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,42 @@
+package com.aidom.api.domain.auth.service;
+
+import com.aidom.api.global.config.AppAuthProperties;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+  static final String ERROR_CODE = "oauth2_login_failed";
+
+  private final AppAuthProperties appAuthProperties;
+
+  public OAuth2AuthenticationFailureHandler(AppAuthProperties appAuthProperties) {
+    this.appAuthProperties = appAuthProperties;
+  }
+
+  @Override
+  public void onAuthenticationFailure(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException exception)
+      throws IOException, ServletException {
+    log.error("OAuth2 login failed: {}", exception.getMessage(), exception);
+
+    String redirectUri =
+        UriComponentsBuilder.fromUriString(appAuthProperties.getOAuth2().getDefaultSuccessUri())
+            .queryParam("error", ERROR_CODE)
+            .build(true)
+            .toUriString();
+
+    getRedirectStrategy().sendRedirect(request, response, redirectUri);
+  }
+}

--- a/src/main/java/com/aidom/api/domain/auth/service/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/aidom/api/domain/auth/service/OAuth2AuthenticationFailureHandler.java
@@ -25,9 +25,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
   @Override
   public void onAuthenticationFailure(
-      HttpServletRequest request,
-      HttpServletResponse response,
-      AuthenticationException exception)
+      HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
       throws IOException, ServletException {
     log.error("OAuth2 login failed: {}", exception.getMessage(), exception);
 

--- a/src/main/java/com/aidom/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/aidom/api/global/config/SecurityConfig.java
@@ -9,7 +9,10 @@ import com.aidom.api.global.security.HttpCookieOAuth2AuthorizationRequestReposit
 import com.aidom.api.global.security.JwtAuthenticationFilter;
 import com.aidom.api.global.security.ProblemDetailAccessDeniedHandler;
 import com.aidom.api.global.security.ProblemDetailAuthenticationEntryPoint;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -24,6 +27,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
+@Slf4j
 @Configuration
 @EnableConfigurationProperties(AppAuthProperties.class)
 public class SecurityConfig {
@@ -90,7 +94,15 @@ public class SecurityConfig {
                           a.authorizationRequestRepository(
                               new HttpCookieOAuth2AuthorizationRequestRepository()))
                   .userInfoEndpoint(endpoint -> endpoint.userService(customOAuth2UserService))
-                  .successHandler(oAuth2AuthenticationSuccessHandler));
+                  .successHandler(oAuth2AuthenticationSuccessHandler)
+                  .failureHandler(
+                      (request, response, exception) -> {
+                        log.error("OAuth2 login failed: {}", exception.getMessage(), exception);
+                        String redirectUri = appAuthProperties.getOAuth2().getDefaultSuccessUri();
+                        String errorMsg =
+                            URLEncoder.encode(exception.getMessage(), StandardCharsets.UTF_8);
+                        response.sendRedirect(redirectUri + "?error=" + errorMsg);
+                      }));
     }
     return http.build();
   }

--- a/src/main/java/com/aidom/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/aidom/api/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.aidom.api.global.config;
 
 import com.aidom.api.domain.auth.service.CustomOAuth2UserService;
+import com.aidom.api.domain.auth.service.OAuth2AuthenticationFailureHandler;
 import com.aidom.api.domain.auth.service.OAuth2AuthenticationSuccessHandler;
 import com.aidom.api.domain.user.enums.Role;
 import com.aidom.api.domain.user.enums.UserStatus;
@@ -9,10 +10,7 @@ import com.aidom.api.global.security.HttpCookieOAuth2AuthorizationRequestReposit
 import com.aidom.api.global.security.JwtAuthenticationFilter;
 import com.aidom.api.global.security.ProblemDetailAccessDeniedHandler;
 import com.aidom.api.global.security.ProblemDetailAuthenticationEntryPoint;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -27,7 +25,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
-@Slf4j
 @Configuration
 @EnableConfigurationProperties(AppAuthProperties.class)
 public class SecurityConfig {
@@ -39,6 +36,7 @@ public class SecurityConfig {
       ProblemDetailAuthenticationEntryPoint authenticationEntryPoint,
       ProblemDetailAccessDeniedHandler accessDeniedHandler,
       CustomOAuth2UserService customOAuth2UserService,
+      OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler,
       OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler,
       ObjectProvider<ClientRegistrationRepository> clientRegistrationRepositoryProvider,
       AppAuthProperties appAuthProperties)
@@ -95,14 +93,7 @@ public class SecurityConfig {
                               new HttpCookieOAuth2AuthorizationRequestRepository()))
                   .userInfoEndpoint(endpoint -> endpoint.userService(customOAuth2UserService))
                   .successHandler(oAuth2AuthenticationSuccessHandler)
-                  .failureHandler(
-                      (request, response, exception) -> {
-                        log.error("OAuth2 login failed: {}", exception.getMessage(), exception);
-                        String redirectUri = appAuthProperties.getOAuth2().getDefaultSuccessUri();
-                        String errorMsg =
-                            URLEncoder.encode(exception.getMessage(), StandardCharsets.UTF_8);
-                        response.sendRedirect(redirectUri + "?error=" + errorMsg);
-                      }));
+                  .failureHandler(oAuth2AuthenticationFailureHandler));
     }
     return http.build();
   }

--- a/src/test/java/com/aidom/api/domain/auth/service/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/com/aidom/api/domain/auth/service/OAuth2AuthenticationFailureHandlerTest.java
@@ -1,0 +1,49 @@
+package com.aidom.api.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.aidom.api.global.config.AppAuthProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationServiceException;
+
+class OAuth2AuthenticationFailureHandlerTest {
+
+  @Test
+  @DisplayName("OAuth2 로그인 실패 시 고정 에러 코드와 함께 프론트로 리다이렉트한다")
+  void onAuthenticationFailure_redirectsWithFixedErrorCode() throws Exception {
+    OAuth2AuthenticationFailureHandler handler = createHandler("https://aidom.kr/login/callback");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    handler.onAuthenticationFailure(
+        request, response, new AuthenticationServiceException("provider detail"));
+
+    assertThat(response.getStatus()).isEqualTo(302);
+    assertThat(response.getRedirectedUrl())
+        .isEqualTo("https://aidom.kr/login/callback?error=oauth2_login_failed");
+  }
+
+  @Test
+  @DisplayName("예외 메시지가 null 이어도 추가 예외 없이 고정 에러 코드로 리다이렉트한다")
+  void onAuthenticationFailure_withNullMessage_redirectsSafely() throws Exception {
+    OAuth2AuthenticationFailureHandler handler =
+        createHandler("https://aidom.kr/login/callback?source=oauth");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    handler.onAuthenticationFailure(request, response, new AuthenticationServiceException(null));
+
+    assertThat(response.getStatus()).isEqualTo(302);
+    assertThat(response.getRedirectedUrl())
+        .isEqualTo("https://aidom.kr/login/callback?source=oauth&error=oauth2_login_failed");
+  }
+
+  private OAuth2AuthenticationFailureHandler createHandler(String redirectUri) {
+    AppAuthProperties appAuthProperties = new AppAuthProperties();
+    appAuthProperties.getOAuth2().setDefaultSuccessUri(redirectUri);
+    return new OAuth2AuthenticationFailureHandler(appAuthProperties);
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- Follow-up to #49

## 작업 내용
OAuth2 로그인 실패 시 백엔드가 403 응답만 반환하던 흐름을 보완했습니다. 프론트로 제어권을 넘기되, 내부 예외 메시지를 그대로 노출하지 않도록 실패 핸들러를 분리하고 외부 계약용 고정 에러 코드만 전달하도록 정리했습니다.

## 변경 사항
- `OAuth2AuthenticationFailureHandler`를 추가해 OAuth2 인증 실패 시 `error=oauth2_login_failed` 쿼리 파라미터와 함께 프론트 리다이렉트 URI로 이동합니다.
- 상세 실패 원인은 서버 로그로만 남기고, 사용자/프론트에는 고정 에러 코드만 노출하도록 변경했습니다.
- 예외 메시지가 `null`이어도 추가 예외 없이 동일한 실패 리다이렉트가 동작하도록 안전 처리했습니다.
- 실패 리다이렉트 계약을 검증하는 단위 테스트를 추가했습니다.

## 체크리스트
- [x] 코드 포맷팅(Checkstyle, Lint 등)을 적용하였는가?
- [x] 테스트 코드를 작성하고 통과했는가?
- [x] 불필요한 console.log / print 등을 제거했는가?
- [x] 로컬 테스트를 완료했는가?
- [ ] 관련 서비스 동작을 확인했는가?

## 테스트
- [x] `./gradlew test --tests '*OAuth2AuthenticationFailureHandlerTest' --tests '*AidomBackendApplicationTests' --tests '*AuthServiceIntegrationTest'`

## 스크린샷
UI 변경 없음.

## 리뷰 포인트
- 프론트가 기대하는 OAuth2 실패 계약을 `error=oauth2_login_failed`로 고정해도 되는지 확인 부탁드립니다.
- 수동 OAuth2 로그인 플로우 확인이 아직 남아 있어, 실제 Kakao/Google 콜백에서도 동일하게 동작하는지 봐주시면 좋겠습니다.